### PR TITLE
[VFS-490] Dont match file extensions to determine mime types of directories

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/impl/FileTypeMap.java
+++ b/core/src/main/java/org/apache/commons/vfs2/impl/FileTypeMap.java
@@ -61,6 +61,12 @@ class FileTypeMap
             return mimeTypeMap.get(mimeType);
         }
 
+        // do not match directories like .../directory.jar/
+        if (!file.isFile())
+        {
+            return null;
+        }
+
         // Check the file's extension for a match
         final String extension = file.getName().getExtension();
         return extensionMap.get(extension);


### PR DESCRIPTION
The problem that the VFSClassLoader tries to expand directories which follow the *.jar pattern are due to the file type detection based on file names is also reacting on folders. This is a possible fix for VFS-490 therefore.