### PR TITLE
[VFS-500] implement VFSClassLoader.findResources and test

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/impl/VFSClassLoader.java
+++ b/core/src/main/java/org/apache/commons/vfs2/impl/VFSClassLoader.java
@@ -25,6 +25,7 @@ import java.security.Permissions;
 import java.security.SecureClassLoader;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.jar.Attributes;
@@ -369,27 +370,32 @@ public class VFSClassLoader extends SecureClassLoader
     /**
      * Returns an Enumeration of all the resources in the search path
      * with the specified name.
-     * TODO - Implement this.
+     *
+     * Gets called from {@link ClassLoader#getResources(String)} after
+     * parent class loader was questioned.
      * @param name The resources to find.
      * @return An Enumeration of the resources associated with the name.
+     * @throws FileSystemException
      */
     @Override
     protected Enumeration<URL> findResources(final String name)
+        throws IOException
     {
-        return new Enumeration<URL>()
-        {
-            @Override
-            public boolean hasMoreElements()
-            {
-                return false;
-            }
+        final ArrayList<URL> result = new ArrayList<URL>(2);
 
-            @Override
-            public URL nextElement()
+        final Iterator<FileObject> it = resources.iterator();
+        while (it.hasNext())
+        {
+            final FileObject baseFile = it.next();
+            final FileObject file =
+                baseFile.resolveFile(name, NameScope.DESCENDENT_OR_SELF);
+            if (file.exists())
             {
-                return null;
+                result.add(new Resource(name, baseFile, file).getURL());
             }
-        };
+        }
+
+        return Collections.enumeration(result);
     }
 
     /**

--- a/core/src/test/java/org/apache/commons/vfs2/impl/test/VfsClassLoaderTests.java
+++ b/core/src/test/java/org/apache/commons/vfs2/impl/test/VfsClassLoaderTests.java
@@ -16,12 +16,18 @@
  */
 package org.apache.commons.vfs2.impl.test;
 
+import java.io.File;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Enumeration;
 
+import org.apache.commons.AbstractVfsTestCase;
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.impl.VFSClassLoader;
 import org.apache.commons.vfs2.test.AbstractProviderTestCase;
 
@@ -94,6 +100,52 @@ public class VfsClassLoaderTests
         assertEquals("code.sealed", pack.getName());
         verifyPackage(pack, true);
     }
+
+    /**
+     * Tests retrieving resources (from JAR searchpath)
+     */
+    public void testGetResourcesJARs() throws Exception
+    {
+        final FileSystemManager manager = getManager();
+        final File baseDir = AbstractVfsTestCase.getTestDirectory();
+
+        // make sure the provider config is useable
+        if (baseDir == null || manager == null || !baseDir.isDirectory())
+            return;
+
+        // build search path without using #getBaseFolder()
+        // because NestedJarTestCase redefines it
+        final FileObject nestedJar;
+        final FileObject testJar;
+        try
+        {
+            nestedJar = manager.resolveFile(baseDir, "nested.jar");
+            testJar = manager.resolveFile(baseDir, "test.jar");
+        }
+        catch (FileSystemException ignored)
+        {
+            return; // this suite cannot handle localFiles
+        }
+
+        final FileObject[] search = new FileObject[] { nestedJar, testJar };
+
+        // test setup needs to know about .jar extension - i.e. NestedJarTestCase
+        if (!manager.canCreateFileSystem(nestedJar))
+            return;
+
+        // verify test setup
+        assertTrue("nested.jar is required for testing", nestedJar.getType() == FileType.FILE);
+        assertTrue("test.jar is required for testing", testJar.getType() == FileType.FILE);
+
+        final VFSClassLoader loader = new VFSClassLoader(search, getManager());
+        final Enumeration<URL> urls = loader.getResources("META-INF/MANIFEST.MF");
+        final URL url1 = urls.nextElement();
+        final URL url2 = urls.nextElement();
+
+        assertTrue("First resource must refer to nested.jar but was " + url1, url1.toString().endsWith("nested.jar!/META-INF/MANIFEST.MF"));
+        assertTrue("Second resource must refer to test.jar but was " + url2, url2.toString().endsWith("test.jar!/META-INF/MANIFEST.MF"));
+    }
+
 
     /**
      * Verify the package loaded with class loader.


### PR DESCRIPTION
This adds VFSClassLoader.findResources() as well as a Unit test. The test is rather complicated to work with all the providers (actually skip most of them). An option would be a TestCase which is not added to all provider tests.

The unit test also verifies actual resource loading from JAR searchPath.

(btw: this is also a test for INFRA-6764 if the pull request mails are received by dev@)
