### PR TITLE
VFS-189: fix issue by checking if base filename is null before using it

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -862,8 +862,11 @@ public class DefaultFileSystemManager implements FileSystemManager
     public FileName resolveName(final FileName base, final String name,
             final NameScope scope) throws FileSystemException
     {
+        if (base == null) {
+            throw new FileSystemException("Invalid base filename.");
+        }
         final FileName realBase;
-        if (base != null && VFS.isUriStyle() && base.isFile())
+        if (VFS.isUriStyle() && base.isFile())
         {
             realBase = base.getParent();
         }

--- a/core/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileSystemManagerTest.java
+++ b/core/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileSystemManagerTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.vfs2.impl.test;
 
 import java.io.File;
 
+import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.VFS;
@@ -55,5 +56,17 @@ public class DefaultFileSystemManagerTest
     {
         String absolute = new File("/").getAbsoluteFile().toURI().toString();
         VFS.getManager().resolveFile((FileObject) null, absolute);
+    }
+
+    /**
+     * If the base name is {@code null}, the file system manager should fail
+     * throwing a FileSystemException.
+     *
+     * @see VFS-189
+     */
+    @Test(expected = FileSystemException.class)
+    public void testResolveFileNameNull() throws FileSystemException
+    {
+        VFS.getManager().resolveName((FileName) null, "../");
     }
 }


### PR DESCRIPTION
Checks if the base filename is null before using, preventing a NPE. More on the rationale for that in the comment entered into the issue for this pull request.
