### PR TITLE
avoid deadlock is AbstractFileSystem.resolveFile()

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -564,28 +564,24 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
      */
     private void detach() throws Exception
     {
-        // no need to enter synchronized block if already detached.
-        if (attached)
+        synchronized (fs)
         {
-            synchronized (fs)
+            if (attached)
             {
-                if (attached)
+                try
                 {
-                    try
-                    {
-                        doDetach();
-                    }
-                    finally
-                    {
-                        attached = false;
-                        setFileType(null);
-                        parent = null;
+                    doDetach();
+                }
+                finally
+                {
+                    attached = false;
+                    setFileType(null);
+                    parent = null;
 
-                        // fs.fileDetached(this);
+                    // fs.fileDetached(this);
 
-                        removeChildrenCache();
-                        // children = null;
-                    }
+                    removeChildrenCache();
+                    // children = null;
                 }
             }
         }

--- a/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -564,24 +564,28 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
      */
     private void detach() throws Exception
     {
-        synchronized (fs)
+        // no need to enter synchronized block if already detached.
+        if (attached)
         {
-            if (attached)
+            synchronized (fs)
             {
-                try
+                if (attached)
                 {
-                    doDetach();
-                }
-                finally
-                {
-                    attached = false;
-                    setFileType(null);
-                    parent = null;
+                    try
+                    {
+                        doDetach();
+                    }
+                    finally
+                    {
+                        attached = false;
+                        setFileType(null);
+                        parent = null;
 
-                    // fs.fileDetached(this);
+                        // fs.fileDetached(this);
 
-                    removeChildrenCache();
-                    // children = null;
+                        removeChildrenCache();
+                        // children = null;
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -155,6 +155,14 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
     }
 
     /**
+     * Allow subclasses to attach the file object without allowing subclasses to override the implementation of the
+     * {@link #attach()} method.
+     */
+    protected void performAttach() throws Exception {
+        attach();
+    }
+
+    /**
      * Attaches to the file.
      * @throws FileSystemException if an error occurs.
      */
@@ -555,6 +563,14 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
 
             return true;
         }
+    }
+
+    /**
+     * Allow subclasses to detach the file object without allowing subclasses to override the implementation of the
+     * {@link #detach()} method.
+     */
+    protected void performDetach() throws Exception {
+        detach();
     }
 
     /**

--- a/core/src/test/java/org/apache/commons/vfs2/provider/http/test/HttpProviderTestCase.java
+++ b/core/src/test/java/org/apache/commons/vfs2/provider/http/test/HttpProviderTestCase.java
@@ -204,7 +204,7 @@ public class HttpProviderTestCase extends AbstractProviderTestConfig
 
     public void testHttp405() throws FileSystemException
     {
-        final FileObject f = VFS.getManager().resolveFile("http://www.w3schools.com/webservices/tempconvert.asmx?action=WSDL");
+        final FileObject f = VFS.getManager().resolveFile("http://www.w3schools.com/xml/tempconvert.asmx?WSDL");
         assert f.getContent().getSize() > 0;
     }
 


### PR DESCRIPTION
Change to "synchronized" bracketing to avoid a potential deadlock.