### PR TITLE
reduce heap by interning / lazy init

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
@@ -44,17 +44,17 @@ public abstract class AbstractFileName implements FileName
     public AbstractFileName(final String scheme, final String absPath, final FileType type)
     {
         this.rootUri = null;
-        this.scheme = scheme;
+        this.scheme = scheme.intern();
         this.type = type;
         if (absPath != null && absPath.length() > 0)
         {
             if (absPath.length() > 1 && absPath.endsWith("/"))
             {
-                this.absPath = absPath.substring(0, absPath.length() - 1);
+                this.absPath = absPath.substring(0, absPath.length() - 1).intern();
             }
             else
             {
-                this.absPath = absPath;
+                this.absPath = absPath.intern();
             }
         }
         else
@@ -137,11 +137,11 @@ public abstract class AbstractFileName implements FileName
             final int idx = getPath().lastIndexOf(SEPARATOR_CHAR);
             if (idx == -1)
             {
-                baseName = getPath();
+                baseName = getPath().intern();
             }
             else
             {
-                baseName = getPath().substring(idx + 1);
+                baseName = getPath().substring(idx + 1).intern();
             }
         }
 
@@ -178,7 +178,7 @@ public abstract class AbstractFileName implements FileName
     {
         if (decodedAbsPath == null)
         {
-            decodedAbsPath = UriParser.decode(getPath());
+            decodedAbsPath = UriParser.decode(getPath()).intern();
         }
 
         return decodedAbsPath;
@@ -245,7 +245,7 @@ public abstract class AbstractFileName implements FileName
     {
         if (uri == null)
         {
-            uri = createURI();
+            uri = createURI().intern();
         }
         return uri;
     }
@@ -408,7 +408,7 @@ public abstract class AbstractFileName implements FileName
             if (pos < 1 || pos == baseName.length() - 1)
             {
                 // No extension
-                extension = "";
+                extension = "".intern();
             }
             else
             {

--- a/core/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileName.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileName.java
@@ -50,7 +50,7 @@ public class LocalFileName extends AbstractFileName
                             final FileType type)
     {
         super(scheme, path, type);
-        this.rootFile = rootFile;
+        this.rootFile = rootFile.intern();
     }
 
     /**

--- a/core/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileObject.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileObject.java
@@ -33,8 +33,8 @@ public class ZipFileObject extends AbstractFileObject<ZipFileSystem>
 {
     /** The ZipEntry. */
     protected ZipEntry entry;
-    private final HashSet<String> children = new HashSet<String>();
-    // protected final ZipFile file;
+    // causes lots of duplication, create on demand
+    private volatile HashSet<String> children = null;
 
     private FileType type;
 
@@ -84,6 +84,8 @@ public class ZipFileObject extends AbstractFileObject<ZipFileSystem>
      */
     public void attachChild(final FileName childName)
     {
+        if (children == null)
+            children = new HashSet<String>();
         children.add(childName.getBaseName());
     }
 
@@ -127,7 +129,10 @@ public class ZipFileObject extends AbstractFileObject<ZipFileSystem>
             throw new RuntimeException(e);
         }
 
-        return children.toArray(new String[children.size()]);
+        if (children == null)
+            return new String[0];
+        else
+            return children.toArray(new String[children.size()]);
     }
 
     /**


### PR DESCRIPTION
This saves about 75% of the heap in ENSIME after quite a bit of memory profiling. It may increase the PermGen requirements of users on Java 6 but will reduce their overall memory consumption.

We have the ability to run with a monkey patched version of VFS, so we are not in any need of you to merge this, but it may benefit other users.

pinging @rgoers @sebbASF explicitly incase you don't check for github PRs.

Provided under the terms of the Apache 2.0 License.