### PR TITLE
updgrade to jcifs 1.3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
       <dependency>
         <groupId>jcifs</groupId>
         <artifactId>jcifs</artifactId>
-        <version>0.8.3</version>
+        <version>1.3.17</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>

--- a/sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileObject.java
+++ b/sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileObject.java
@@ -227,7 +227,7 @@ public class SmbFileObject
         }
         catch (final SmbException e)
         {
-            if (e.getErrorCode() == SmbException.ERRbadfile)
+            if (e.getNtStatus() == SmbException.NT_STATUS_NO_SUCH_FILE)
             {
                 throw new org.apache.commons.vfs2.FileNotFoundException(getName());
             }

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -102,7 +102,7 @@
                 <tr>
                     <td>
                         <a href="http://jcifs.samba.org/">jCIFS</a>
-                        Version 0.8.3.
+                        Version 1.3.17.
                     </td>
                     <td>CIFS (VFS sandbox)</td>
                 </tr>


### PR DESCRIPTION
An upgrade from a very old jcifs to almost the new one 
(The newest one is 1.3.18, but is not in the maven repository).