### PR TITLE
AbstractFileObject: call doGetType() without holding the lock

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
@@ -187,18 +187,14 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
      */
     @Override
     protected FileType doGetType() throws Exception {
-        try {
-            doAttach();
-            if (null == stat) {
-                return FileType.IMAGINARY;
-            }
-            if (stat.isDirectory()) {
-                return FileType.FOLDER;
-            }
-            return FileType.FILE;
-        } catch (final FileNotFoundException fnfe) {
+        doAttach();
+        if (null == stat) {
             return FileType.IMAGINARY;
         }
+        if (stat.isDirectory()) {
+            return FileType.FOLDER;
+        }
+        return FileType.FILE;
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
@@ -293,20 +293,4 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
         return true;
     }
 
-    /**
-     * @see org.apache.commons.vfs2.provider.AbstractFileObject#exists()
-     * @return boolean true if file exists, false if not
-     */
-    @Override
-    public boolean exists() throws FileSystemException {
-        try {
-            doAttach();
-            return this.stat != null;
-        } catch (final FileNotFoundException fne) {
-            return false;
-        } catch (final Exception e) {
-            throw new FileSystemException("Unable to check existance ", e);
-        }
-    }
-
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
@@ -90,7 +90,6 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
             this.stat = this.hdfs.getFileStatus(this.path);
         } catch (final FileNotFoundException e) {
             this.stat = null;
-            return;
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
@@ -82,14 +82,15 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
     }
 
     /**
-     * @see org.apache.commons.vfs2.provider.AbstractFileObject#doAttach()
+     * Obtains the #FileStatus instance or null if the file does not exist.
+     *
+     * Throws on error.
      */
-    @Override
-    protected void doAttach() throws Exception {
+    private FileStatus getStatus() throws Exception {
         try {
-            this.stat = this.hdfs.getFileStatus(this.path);
+            return this.stat = this.hdfs.getFileStatus(this.path);
         } catch (final FileNotFoundException e) {
-            this.stat = null;
+            return this.stat = null;
         }
     }
 
@@ -116,17 +117,18 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
      */
     @Override
     protected Map<String, Object> doGetAttributes() throws Exception {
-        if (null == this.stat) {
+        final FileStatus status = getStatus();
+        if (null == status) {
             return super.doGetAttributes();
         }
         final Map<String, Object> attrs = new HashMap<>();
-        attrs.put(HdfsFileAttributes.LAST_ACCESS_TIME.toString(), this.stat.getAccessTime());
-        attrs.put(HdfsFileAttributes.BLOCK_SIZE.toString(), this.stat.getBlockSize());
-        attrs.put(HdfsFileAttributes.GROUP.toString(), this.stat.getGroup());
-        attrs.put(HdfsFileAttributes.OWNER.toString(), this.stat.getOwner());
-        attrs.put(HdfsFileAttributes.PERMISSIONS.toString(), this.stat.getPermission().toString());
-        attrs.put(HdfsFileAttributes.LENGTH.toString(), this.stat.getLen());
-        attrs.put(HdfsFileAttributes.MODIFICATION_TIME.toString(), this.stat.getModificationTime());
+        attrs.put(HdfsFileAttributes.LAST_ACCESS_TIME.toString(), status.getAccessTime());
+        attrs.put(HdfsFileAttributes.BLOCK_SIZE.toString(), status.getBlockSize());
+        attrs.put(HdfsFileAttributes.GROUP.toString(), status.getGroup());
+        attrs.put(HdfsFileAttributes.OWNER.toString(), status.getOwner());
+        attrs.put(HdfsFileAttributes.PERMISSIONS.toString(), status.getPermission().toString());
+        attrs.put(HdfsFileAttributes.LENGTH.toString(), status.getLen());
+        attrs.put(HdfsFileAttributes.MODIFICATION_TIME.toString(), status.getModificationTime());
         return attrs;
     }
 
@@ -135,6 +137,7 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
      */
     @Override
     protected long doGetContentSize() throws Exception {
+        final FileStatus stat = getStatus();
         return stat.getLen();
     }
 
@@ -151,9 +154,9 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
      */
     @Override
     protected long doGetLastModifiedTime() throws Exception {
-        doAttach();
-        if (null != this.stat) {
-            return this.stat.getModificationTime();
+        final FileStatus status = getStatus();
+        if (null != status) {
+            return status.getModificationTime();
         }
         return -1;
     }
@@ -187,7 +190,7 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
      */
     @Override
     protected FileType doGetType() throws Exception {
-        doAttach();
+        final FileStatus stat = getStatus();
         if (null == stat) {
             return FileType.IMAGINARY;
         }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http/HttpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http/HttpFileObject.java
@@ -206,7 +206,7 @@ public class HttpFileObject<FS extends HttpFileSystem> extends AbstractFileObjec
         return userAgent;
     }
 
-    HeadMethod getHeadMethod() throws IOException {
+    synchronized HeadMethod getHeadMethod() throws IOException {
         if (method != null) {
             return method;
         }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -71,7 +71,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
      * Determines the type of this file, returns null if the file does not exist.
      */
     @Override
-    protected FileType doGetType() throws Exception {
+    protected synchronized FileType doGetType() throws Exception {
         if (attrs == null) {
             statSelf();
         }
@@ -102,7 +102,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
      *
      * @throws IOException
      */
-    private void statSelf() throws IOException {
+    private synchronized void statSelf() throws IOException {
         ChannelSftp channel = getAbstractFileSystem().getChannel();
         try {
             setStat(channel.stat(relPath));
@@ -136,7 +136,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
     /**
      * Sets attrs from listChildrenResolved
      */
-    private void setStat(final SftpATTRS attrs) {
+    private synchronized void setStat(final SftpATTRS attrs) {
         this.attrs = attrs;
     }
 


### PR DESCRIPTION
To reduce lock contention.  doGetType() does not need to be protected,
but does synchronous I/O and can run for a long time (if the NFS
server is slow to respond).  This would block all other calls to the
same FileSystem instance.