### PR TITLE
String intern consuming much time during the performance testing

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -225,7 +225,7 @@ public final class UriParser {
                 if (buffer != null) {
                     buffer.delete(0, pos + 1);
                 }
-                return scheme.intern();
+                return scheme;
             }
 
             if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {


### PR DESCRIPTION
We have tested our VFS tests and during the profiling we see the string.intern method taking much of cpu time. Do we really need to intern the scheme string here ?