### PR TITLE
pom.xml: renable commented-out cobertura-maven-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ jdk:
   - oraclejdk8
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn clean cobertura:cobertura coveralls:report -Ptravis-cobertura

--- a/pom.xml
+++ b/pom.xml
@@ -334,14 +334,11 @@
           <aggregate>true</aggregate>
         </configuration>
       </plugin>
-      <!-- cobertura breaks because it cannot parse annotations in methods. -->
-      <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>${commons.cobertura.version}</version>
       </plugin>
-      -->
       <!-- javancss breaks because it cannot parse annotations in methods. -->
       <!--
       <plugin>


### PR DESCRIPTION
.travis.yml: use travis cobertura profile from commons-parent