### PR TITLE
SFTP: Perform less strict permission checks on servers where the exec channel is disabled

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/DummyPosixPermissions.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/DummyPosixPermissions.java
@@ -1,0 +1,13 @@
+package org.apache.commons.vfs2.provider.sftp;
+
+import org.apache.commons.vfs2.util.PosixPermissions;
+
+/**
+ * Pretends that the current user is always the owner and in the same group.
+ */
+public class DummyPosixPermissions extends PosixPermissions {
+
+    public DummyPosixPermissions(final int permissions) {
+        super(permissions, true, true);
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -249,6 +249,13 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
         statSelf();
         boolean isInGroup = false;
         if (checkIds) {
+            if(getAbstractFileSystem().isExecDisabled()) {
+                // Exec is disabled, so we won't be able to ascertain the current user's UID and GID.
+                // Return "always-true" permissions as a workaround, knowing that the SFTP server won't 
+                // let us perform unauthorized actions anyway.
+                return new DummyPosixPermissions(attrs.getPermissions());
+            }
+
             for (final int groupId : getAbstractFileSystem().getGroupsIds()) {
                 if (groupId == attrs.getGId()) {
                     isInGroup = true;


### PR DESCRIPTION
Prior to this patch, all permissions checks would fail on servers
without an exec channel: SftpFileObject relied on the knowledge of the
current user's UID and GID. Neither of these can be obtained without an
exec channel. The SFTP specifications do not appear to mention any
alternative method of ascertaining the UID/GID.

As a workaround, when the UID can't be detected, SftpFileObject will use
a DummyPosixPermissions instance, which always "grants" RWX.

There are two sides to this coin:

1. This will allow normal operation against SFTP servers without an exec
channel.
2. This may cause JSchExceptions to be thrown when the actual
permissions are inconsistent with the dummy permissions.

This seems to be preferable to not being able to use exec-less SFTP
servers. Regressions should be limited to these kinds of servers.

Calling getUId when first making a connection might impose an overhead,
but this is presumably a trivial one.

This will probably fix VFS-590 and VFS-617.

This solution could be made a bit more elegant, perhaps by making this check optional, or by using an alternative way to detect whether the exec channel is present.  