### PR TITLE
fixed for AbstractFileObject#toString leak password!

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -1782,6 +1782,6 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
      */
     @Override
     public String toString() {
-        return fileName.getURI();
+        return fileName.getFriendlyURI();
     }
 }


### PR DESCRIPTION
change  fileName.getURI() to fileName.getFriendlyURI() for improve security( mask password )