### PR TITLE
VFS-398 FtpFileObject.getChildren() fails when a folder contains a file with a colon in the name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 .classpath
 .settings/
 .svn/
+.idea/
+*.iml

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -175,7 +175,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
      * @throws FileSystemException if an error occurs adding the provider.
      */
     public void addProvider(final String urlScheme, final FileProvider provider) throws FileSystemException {
-        addProvider(new String[] { urlScheme }, provider);
+        addProvider(new String[] {urlScheme}, provider);
     }
 
     /**
@@ -346,7 +346,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
         }
 
         try {
-            fileObjectDecoratorConst = fileObjectDecorator.getConstructor(new Class[] { FileObject.class });
+            fileObjectDecoratorConst = fileObjectDecorator.getConstructor(new Class[] {FileObject.class});
         } catch (final NoSuchMethodException e) {
             throw new FileSystemException("vfs.impl/invalid-decorator.error", fileObjectDecorator.getName(), e);
         }
@@ -708,7 +708,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
         }
 
         // Extract the scheme
-        final String scheme = UriParser.extractScheme(getSchemes(),uri);
+        final String scheme = UriParser.extractScheme(getSchemes(), uri);
         if (scheme != null) {
             // An absolute URI - locate the provider
             final FileProvider provider = providers.get(scheme);
@@ -1037,10 +1037,22 @@ public class DefaultFileSystemManager implements FileSystemManager {
      */
     @Override
     public String[] getSchemes() {
-        final List<String> schemes = new ArrayList<>(providers.size() + virtualFileSystemSchemes.size());
-        schemes.addAll(providers.keySet());
-        schemes.addAll(virtualFileSystemSchemes);
-        return schemes.toArray(new String[]{});
+       int index = 0;
+       int providerSize = providers.size();
+       int vfsSchemesSize = virtualFileSystemSchemes.size();
+       String[] schemes = new String[ providerSize + vfsSchemesSize];
+
+       for (String scheme : providers.keySet()) {
+           schemes[index] = scheme;
+           index++;
+       }
+
+       for (String scheme : virtualFileSystemSchemes) {
+           schemes[index] = scheme;
+           index++;
+       }
+
+       return schemes;
     }
 
     /**
@@ -1085,7 +1097,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
     @Override
     public void addOperationProvider(final String scheme, final FileOperationProvider operationProvider)
             throws FileSystemException {
-        addOperationProvider(new String[] { scheme }, operationProvider);
+        addOperationProvider(new String[] {scheme}, operationProvider);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -559,6 +559,9 @@ public class DefaultFileSystemManager implements FileSystemManager {
         // managed components
         vfsProvider = null;
 
+        // virtual schemas
+        virtualFileSystemSchemes.clear();
+
         // setters and derived state
         defaultProvider = null;
         baseFile = null;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -775,7 +775,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
 
         // Adjust separators
         UriParser.fixSeparators(buffer);
-        String scheme = UriParser.extractScheme(buffer.toString());
+        String scheme = UriParser.extractSupportedScheme(providers.keySet(), buffer.toString());
 
         // Determine whether to prepend the base path
         if (name.length() == 0 || (scheme == null && buffer.charAt(0) != FileName.SEPARATOR_CHAR)) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -67,6 +67,11 @@ public class DefaultFileSystemManager implements FileSystemManager {
     private final Map<String, FileProvider> providers = new HashMap<>();
 
     /**
+     * Cache of schemes currently supported.
+     */
+    private String[] cachedSchemes;
+
+    /**
      * List of the schemes of virtual filesystems added.
      */
     private final List<String> virtualFileSystemSchemes = new ArrayList<>();
@@ -207,6 +212,9 @@ public class DefaultFileSystemManager implements FileSystemManager {
         if (provider instanceof LocalFileProvider && localFileProvider == null) {
             localFileProvider = (LocalFileProvider) provider;
         }
+
+        // invalidate the scheme cache
+        cachedSchemes = null;
     }
 
     /**
@@ -561,6 +569,9 @@ public class DefaultFileSystemManager implements FileSystemManager {
 
         // virtual schemas
         virtualFileSystemSchemes.clear();
+
+        // cached schemes
+        cachedSchemes = null;
 
         // setters and derived state
         defaultProvider = null;
@@ -955,6 +966,7 @@ public class DefaultFileSystemManager implements FileSystemManager {
             rootUri = rootUri.substring(0, rootUri.indexOf(':'));
         }
         virtualFileSystemSchemes.add(rootUri);
+        cachedSchemes = null;
     }
 
     /**
@@ -1037,22 +1049,25 @@ public class DefaultFileSystemManager implements FileSystemManager {
      */
     @Override
     public String[] getSchemes() {
-       int index = 0;
-       int providerSize = providers.size();
-       int vfsSchemesSize = virtualFileSystemSchemes.size();
-       String[] schemes = new String[ providerSize + vfsSchemesSize];
+        if (cachedSchemes == null) {
+            int index = 0;
+            int providerSize = providers.size();
+            int vfsSchemesSize = virtualFileSystemSchemes.size();
+            final String[] schemes = new String[providerSize + vfsSchemesSize];
 
-       for (String scheme : providers.keySet()) {
-           schemes[index] = scheme;
-           index++;
-       }
+            for (String scheme : providers.keySet()) {
+                schemes[index] = scheme;
+                index++;
+            }
 
-       for (String scheme : virtualFileSystemSchemes) {
-           schemes[index] = scheme;
-           index++;
-       }
+            for (String scheme : virtualFileSystemSchemes) {
+                schemes[index] = scheme;
+                index++;
+            }
 
-       return schemes;
+            cachedSchemes = schemes;
+        }
+        return cachedSchemes;
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -47,6 +47,7 @@ import org.apache.commons.vfs2.FileUtil;
 import org.apache.commons.vfs2.NameScope;
 import org.apache.commons.vfs2.RandomAccessContent;
 import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.operations.DefaultFileOperations;
 import org.apache.commons.vfs2.operations.FileOperations;
 import org.apache.commons.vfs2.util.FileObjectUtils;
@@ -1308,9 +1309,9 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
         try {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<URL>() {
                 @Override
-                public URL run() throws MalformedURLException {
+                public URL run() throws MalformedURLException, FileSystemException {
                     final StringBuilder buf = new StringBuilder();
-                    final String scheme = UriParser.extractScheme(fileName.getURI(), buf);
+                    final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), fileName.getURI(), buf);
                     return new URL(scheme, "", -1, buf.toString(),
                             new DefaultURLStreamHandler(fileSystem.getContext(), fileSystem.getFileSystemOptions()));
                 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/CompositeFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/CompositeFileProvider.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.provider;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
 
 /**
  * Description.
@@ -51,7 +52,7 @@ public abstract class CompositeFileProvider extends AbstractFileProvider {
             throws FileSystemException {
         final StringBuilder buf = new StringBuilder(INITIAL_BUFSZ);
 
-        UriParser.extractScheme(uri, buf);
+        UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buf);
 
         final String[] schemes = getSchemes();
         for (final String scheme : schemes) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultURLStreamHandler.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultURLStreamHandler.java
@@ -24,6 +24,7 @@ import java.net.URLStreamHandler;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
 
 /**
  * A default URL stream handler that will work for most file systems.
@@ -66,7 +67,7 @@ public class DefaultURLStreamHandler extends URLStreamHandler {
 
             final String url = newURL.getName().getURI();
             final StringBuilder filePart = new StringBuilder();
-            final String protocolPart = UriParser.extractScheme(url, filePart);
+            final String protocolPart = UriParser.extractScheme(VFS.getManager().getSchemes(), url, filePart);
 
             setURL(u, protocolPart, "", -1, null, null, filePart.toString(), null, null);
         } catch (final FileSystemException fse) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.provider;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.util.Cryptor;
 import org.apache.commons.vfs2.util.CryptorFactory;
 
@@ -71,7 +72,7 @@ public class HostFileNameParser extends AbstractFileNameParser {
         final Authority auth = new Authority();
 
         // Extract the scheme
-        auth.scheme = UriParser.extractScheme(uri, name);
+        auth.scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), uri, name);
 
         // Expecting "//"
         if (name.length() < 2 || name.charAt(0) != '/' || name.charAt(1) != '/') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/LayeredFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/LayeredFileNameParser.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.provider;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.VFS;
 
 /**
  * Implementation for layered filesystems.
@@ -63,7 +64,7 @@ public class LayeredFileNameParser extends AbstractFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme
-        final String scheme = UriParser.extractScheme(filename, name);
+        final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), filename, name);
 
         // Extract the Layered file URI
         final String rootUriName = extractRootName(name);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -194,7 +194,9 @@ public final class UriParser {
      *
      * @param uri The URI.
      * @return The scheme name. Returns null if there is no scheme.
+     * @deprecated Use instead {@link #extractSupportedScheme}.  Will be removed in 3.0.
      */
+    @Deprecated
     public static String extractScheme(final String uri) {
         return extractScheme(uri, null);
     }
@@ -205,7 +207,9 @@ public final class UriParser {
      * @param uri The URI.
      * @param buffer Returns the remainder of the URI.
      * @return The scheme name. Returns null if there is no scheme.
+     * @deprecated Use instead {@link #extractSupportedScheme}.  Will be removed in 3.0.
      */
+    @Deprecated
     public static String extractScheme(final String uri, final StringBuilder buffer) {
         if (buffer != null) {
             buffer.setLength(0);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.vfs2.provider;
 
+import java.util.Set;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
@@ -244,6 +245,26 @@ public final class UriParser {
         }
 
         // No scheme in URI
+        return null;
+    }
+    public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri) {
+        return extractSupportedScheme(supportedScheme, uri, null);
+    }
+
+    public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri, StringBuilder buffer) {
+        if (buffer != null) {
+            buffer.setLength(0);
+            buffer.append(uri);
+        }
+
+        for(String schema : supportedScheme) {
+            if(uri.startsWith(schema + ":")) {
+                if (buffer != null) {
+                    buffer.delete(0, uri.indexOf(':') + 1);
+                }
+                return schema;
+            }
+        }
         return null;
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -247,10 +247,38 @@ public final class UriParser {
         // No scheme in URI
         return null;
     }
+
+    /**
+     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
+     * <p>
+     * The scheme is extracted based on the currently supported schemes in the system.  That is to say the schemes
+     * supported by the registered providers.
+     * </p>
+     * <p>
+     * This allows us to handle varying scheme's without making assumptions based on the ':' character.  Specifically
+     * handle scheme extraction calls for uri parameters that are not actually uri's, but may be names with ':' in them.
+     * </p>
+     * @param uri The potential URI. May also be a name.
+     * @return The scheme name. Returns null if there is no scheme.
+     */
     public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri) {
         return extractSupportedScheme(supportedScheme, uri, null);
     }
 
+    /**
+     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
+     * <p>
+     * The scheme is extracted based on the currently supported schemes in the system.  That is to say the schemes
+     * supported by the registered providers.
+     * </p>
+     * <p>
+     * This allows us to handle varying scheme's without making assumptions based on the ':' character. Specifically
+     * handle scheme extraction calls for uri parameters that are not actually uri's, but may be names with ':' in them.
+     * </p>
+     * @param uri The potential URI. May also just be a name.
+     * @param buffer Returns the remainder of the URI.
+     * @return The scheme name. Returns null if there is no scheme.
+     */
     public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri, StringBuilder buffer) {
         if (buffer != null) {
             buffer.setLength(0);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -47,7 +47,203 @@ public final class UriParser {
 
     private static final char LOW_MASK = 0x0F;
 
-    private UriParser() {
+    /**
+     * Encodes and appends a string to a StringBuilder.
+     *
+     * @param buffer The StringBuilder to append to.
+     * @param unencodedValue The String to encode and append.
+     * @param reserved characters to encode.
+     */
+    public static void appendEncoded(final StringBuilder buffer, final String unencodedValue, final char[] reserved) {
+        final int offset = buffer.length();
+        buffer.append(unencodedValue);
+        encode(buffer, offset, unencodedValue.length(), reserved);
+    }
+
+    public static void canonicalizePath(final StringBuilder buffer, final int offset, final int length,
+            final FileNameParser fileNameParser) throws FileSystemException {
+        int index = offset;
+        int count = length;
+        for (; count > 0; count--, index++) {
+            final char ch = buffer.charAt(index);
+            if (ch == '%') {
+                if (count < 3) {
+                    throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
+                            buffer.substring(index, index + count));
+                }
+
+                // Decode
+                final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
+                final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
+                if (dig1 == -1 || dig2 == -1) {
+                    throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
+                            buffer.substring(index, index + 3));
+                }
+                final char value = (char) (dig1 << BITS_IN_HALF_BYTE | dig2);
+
+                final boolean match = value == '%' || fileNameParser.encodeCharacter(value);
+
+                if (match) {
+                    // this is a reserved character, not allowed to decode
+                    index += 2;
+                    count -= 2;
+                    continue;
+                }
+
+                // Replace
+                buffer.setCharAt(index, value);
+                buffer.delete(index + 1, index + 3);
+                count -= 2;
+            } else if (fileNameParser.encodeCharacter(ch)) {
+                // Encode
+                final char[] digits = { Character.forDigit((ch >> BITS_IN_HALF_BYTE) & LOW_MASK, HEX_BASE),
+                        Character.forDigit(ch & LOW_MASK, HEX_BASE) };
+                buffer.setCharAt(index, '%');
+                buffer.insert(index + 1, digits);
+                index += 2;
+            }
+        }
+    }
+
+    /**
+     * Decodes the String.
+     *
+     * @param uri The String to decode.
+     * @throws FileSystemException if an error occurs.
+     */
+    public static void checkUriEncoding(final String uri) throws FileSystemException {
+        decode(uri);
+    }
+
+    /**
+     * Removes %nn encodings from a string.
+     *
+     * @param encodedStr The encoded String.
+     * @return The decoded String.
+     * @throws FileSystemException if an error occurs.
+     */
+    public static String decode(final String encodedStr) throws FileSystemException {
+        if (encodedStr == null) {
+            return null;
+        }
+        if (encodedStr.indexOf('%') < 0) {
+            return encodedStr;
+        }
+        final StringBuilder buffer = new StringBuilder(encodedStr);
+        decode(buffer, 0, buffer.length());
+        return buffer.toString();
+    }
+
+    /**
+     * Removes %nn encodings from a string.
+     *
+     * @param buffer StringBuilder containing the string to decode.
+     * @param offset The position in the string to start decoding.
+     * @param length The number of characters to decode.
+     * @throws FileSystemException if an error occurs.
+     */
+    public static void decode(final StringBuilder buffer, final int offset, final int length)
+            throws FileSystemException {
+        int index = offset;
+        int count = length;
+        for (; count > 0; count--, index++) {
+            final char ch = buffer.charAt(index);
+            if (ch != '%') {
+                continue;
+            }
+            if (count < 3) {
+                throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
+                        buffer.substring(index, index + count));
+            }
+
+            // Decode
+            final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
+            final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
+            if (dig1 == -1 || dig2 == -1) {
+                throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
+                        buffer.substring(index, index + 3));
+            }
+            final char value = (char) (dig1 << BITS_IN_HALF_BYTE | dig2);
+
+            // Replace
+            buffer.setCharAt(index, value);
+            buffer.delete(index + 1, index + 3);
+            count -= 2;
+        }
+    }
+
+    /**
+     * Removes %nn encodings from a string.
+     *
+     * @param decodedStr The decoded String.
+     * @return The encoded String.
+     */
+    public static String encode(final String decodedStr) {
+        return encode(decodedStr, null);
+    }
+
+    /**
+     * Converts "special" characters to their %nn value.
+     *
+     * @param decodedStr The decoded String.
+     * @param reserved Characters to encode.
+     * @return The encoded String
+     */
+    public static String encode(final String decodedStr, final char[] reserved) {
+        if (decodedStr == null) {
+            return null;
+        }
+        final StringBuilder buffer = new StringBuilder(decodedStr);
+        encode(buffer, 0, buffer.length(), reserved);
+        return buffer.toString();
+    }
+
+    /**
+     * Encode an array of Strings.
+     *
+     * @param strings The array of Strings to encode.
+     * @return An array of encoded Strings.
+     */
+    public static String[] encode(final String[] strings) {
+        if (strings == null) {
+            return null;
+        }
+        for (int i = 0; i < strings.length; i++) {
+            strings[i] = encode(strings[i]);
+        }
+        return strings;
+    }
+
+    /**
+     * Encodes a set of reserved characters in a StringBuilder, using the URI %nn encoding. Always encodes % characters.
+     *
+     * @param buffer The StringBuilder to append to.
+     * @param offset The position in the buffer to start encoding at.
+     * @param length The number of characters to encode.
+     * @param reserved characters to encode.
+     */
+    public static void encode(final StringBuilder buffer, final int offset, final int length, final char[] reserved) {
+        int index = offset;
+        int count = length;
+        for (; count > 0; index++, count--) {
+            final char ch = buffer.charAt(index);
+            boolean match = ch == '%';
+            if (reserved != null) {
+                for (int i = 0; !match && i < reserved.length; i++) {
+                    if (ch == reserved[i]) {
+                        match = true;
+                    }
+                }
+            }
+            if (match) {
+                // Encode
+                final char[] digits = { Character.forDigit((ch >> BITS_IN_HALF_BYTE) & LOW_MASK, HEX_BASE),
+                        Character.forDigit(ch & LOW_MASK, HEX_BASE) };
+                buffer.setCharAt(index, '%');
+                buffer.insert(index + 1, digits);
+                index += 2;
+            }
+        }
     }
 
     /**
@@ -78,6 +274,155 @@ public final class UriParser {
         final String elem = name.substring(startPos);
         name.setLength(0);
         return elem;
+    }
+
+    /**
+     * Extract the query String from the URI.
+     *
+     * @param name StringBuilder containing the URI.
+     * @return The query string, if any. null otherwise.
+     */
+    public static String extractQueryString(final StringBuilder name) {
+        for (int pos = 0; pos < name.length(); pos++) {
+            if (name.charAt(pos) == '?') {
+                final String queryString = name.substring(pos + 1);
+                name.delete(pos, name.length());
+                return queryString;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
+     * <p>
+     * The scheme is extracted based on the currently supported schemes in the system.  That is to say the schemes
+     * supported by the registered providers.
+     * </p>
+     * <p>
+     * This allows us to handle varying scheme's without making assumptions based on the ':' character.  Specifically
+     * handle scheme extraction calls for URI parameters that are not actually uri's, but may be names with ':' in them.
+     * </p>
+     * @param schemes The schemes to check.
+     * @param uri The potential URI. May also be a name.
+     * @return The scheme name. Returns null if there is no scheme.
+     */
+    public static String extractScheme(final String[] schemes, final String uri) {
+        return extractScheme(schemes, uri, null);
+    }
+
+    /**
+     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
+     * <p>
+     * The scheme is extracted based on the given set of schemes. Normally, that is to say the schemes
+     * supported by the registered providers.
+     * </p>
+     * <p>
+     * This allows us to handle varying scheme's without making assumptions based on the ':' character. Specifically
+     * handle scheme extraction calls for URI parameters that are not actually uri's, but may be names with ':' in them.
+     * </p>
+     * @param schemes The schemes to check.
+     * @param uri The potential URI. May also just be a name.
+     * @param buffer Returns the remainder of the URI.
+     * @return The scheme name. Returns null if there is no scheme.
+     */
+    public static String extractScheme(final String[] schemes, final String uri, StringBuilder buffer) {
+        if (buffer != null) {
+            buffer.setLength(0);
+            buffer.append(uri);
+        }
+        for(String scheme : schemes) {
+            if(uri.startsWith(scheme + ":")) {
+                if (buffer != null) {
+                    buffer.delete(0, uri.indexOf(':') + 1);
+                }
+                return scheme;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the scheme from a URI.
+     *
+     * @param uri The URI.
+     * @return The scheme name. Returns null if there is no scheme.
+     * @deprecated Use instead {@link #extractScheme}.  Will be removed in 3.0.
+     */
+    @Deprecated
+    public static String extractScheme(final String uri) {
+        return extractScheme(uri, null);
+    }
+
+    /**
+     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
+     *
+     * @param uri The URI.
+     * @param buffer Returns the remainder of the URI.
+     * @return The scheme name. Returns null if there is no scheme.
+     * @deprecated Use instead {@link #extractScheme}.  Will be removed in 3.0.
+     */
+    @Deprecated
+    public static String extractScheme(final String uri, final StringBuilder buffer) {
+        if (buffer != null) {
+            buffer.setLength(0);
+            buffer.append(uri);
+        }
+
+        final int maxPos = uri.length();
+        for (int pos = 0; pos < maxPos; pos++) {
+            final char ch = uri.charAt(pos);
+
+            if (ch == ':') {
+                // Found the end of the scheme
+                final String scheme = uri.substring(0, pos);
+                if (scheme.length() <= 1 && Os.isFamily(Os.OS_FAMILY_WINDOWS)) {
+                    // This is not a scheme, but a Windows drive letter
+                    return null;
+                }
+                if (buffer != null) {
+                    buffer.delete(0, pos + 1);
+                }
+                return scheme.intern();
+            }
+
+            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+                // A scheme character
+                continue;
+            }
+            if (pos > 0 && ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.')) {
+                // A scheme character (these are not allowed as the first
+                // character of the scheme, but can be used as subsequent
+                // characters.
+                continue;
+            }
+
+            // Not a scheme character
+            break;
+        }
+
+        // No scheme in URI
+        return null;
+    }
+
+    /**
+     * Normalises the separators in a name.
+     *
+     * @param name The StringBuilder containing the name
+     * @return true if the StringBuilder was modified.
+     */
+    public static boolean fixSeparators(final StringBuilder name) {
+        boolean changed = false;
+        final int maxlen = name.length();
+        for (int i = 0; i < maxlen; i++) {
+            final char ch = name.charAt(i);
+            if (ch == TRANS_SEPARATOR) {
+                name.setCharAt(i, SEPARATOR_CHAR);
+                changed = true;
+            }
+        }
+        return changed;
     }
 
     /**
@@ -170,350 +515,6 @@ public final class UriParser {
         return fileType;
     }
 
-    /**
-     * Normalises the separators in a name.
-     *
-     * @param name The StringBuilder containing the name
-     * @return true if the StringBuilder was modified.
-     */
-    public static boolean fixSeparators(final StringBuilder name) {
-        boolean changed = false;
-        final int maxlen = name.length();
-        for (int i = 0; i < maxlen; i++) {
-            final char ch = name.charAt(i);
-            if (ch == TRANS_SEPARATOR) {
-                name.setCharAt(i, SEPARATOR_CHAR);
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    /**
-     * Extracts the scheme from a URI.
-     *
-     * @param uri The URI.
-     * @return The scheme name. Returns null if there is no scheme.
-     * @deprecated Use instead {@link #extractSupportedScheme}.  Will be removed in 3.0.
-     */
-    @Deprecated
-    public static String extractScheme(final String uri) {
-        return extractScheme(uri, null);
-    }
-
-    /**
-     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
-     *
-     * @param uri The URI.
-     * @param buffer Returns the remainder of the URI.
-     * @return The scheme name. Returns null if there is no scheme.
-     * @deprecated Use instead {@link #extractSupportedScheme}.  Will be removed in 3.0.
-     */
-    @Deprecated
-    public static String extractScheme(final String uri, final StringBuilder buffer) {
-        if (buffer != null) {
-            buffer.setLength(0);
-            buffer.append(uri);
-        }
-
-        final int maxPos = uri.length();
-        for (int pos = 0; pos < maxPos; pos++) {
-            final char ch = uri.charAt(pos);
-
-            if (ch == ':') {
-                // Found the end of the scheme
-                final String scheme = uri.substring(0, pos);
-                if (scheme.length() <= 1 && Os.isFamily(Os.OS_FAMILY_WINDOWS)) {
-                    // This is not a scheme, but a Windows drive letter
-                    return null;
-                }
-                if (buffer != null) {
-                    buffer.delete(0, pos + 1);
-                }
-                return scheme.intern();
-            }
-
-            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
-                // A scheme character
-                continue;
-            }
-            if (pos > 0 && ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.')) {
-                // A scheme character (these are not allowed as the first
-                // character of the scheme, but can be used as subsequent
-                // characters.
-                continue;
-            }
-
-            // Not a scheme character
-            break;
-        }
-
-        // No scheme in URI
-        return null;
-    }
-
-    /**
-     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
-     * <p>
-     * The scheme is extracted based on the currently supported schemes in the system.  That is to say the schemes
-     * supported by the registered providers.
-     * </p>
-     * <p>
-     * This allows us to handle varying scheme's without making assumptions based on the ':' character.  Specifically
-     * handle scheme extraction calls for uri parameters that are not actually uri's, but may be names with ':' in them.
-     * </p>
-     * @param uri The potential URI. May also be a name.
-     * @return The scheme name. Returns null if there is no scheme.
-     */
-    public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri) {
-        return extractSupportedScheme(supportedScheme, uri, null);
-    }
-
-    /**
-     * Extracts the scheme from a URI. Removes the scheme and ':' delimiter from the front of the URI.
-     * <p>
-     * The scheme is extracted based on the currently supported schemes in the system.  That is to say the schemes
-     * supported by the registered providers.
-     * </p>
-     * <p>
-     * This allows us to handle varying scheme's without making assumptions based on the ':' character. Specifically
-     * handle scheme extraction calls for uri parameters that are not actually uri's, but may be names with ':' in them.
-     * </p>
-     * @param uri The potential URI. May also just be a name.
-     * @param buffer Returns the remainder of the URI.
-     * @return The scheme name. Returns null if there is no scheme.
-     */
-    public static String extractSupportedScheme(final Set<String> supportedScheme, final String uri, StringBuilder buffer) {
-        if (buffer != null) {
-            buffer.setLength(0);
-            buffer.append(uri);
-        }
-
-        for(String schema : supportedScheme) {
-            if(uri.startsWith(schema + ":")) {
-                if (buffer != null) {
-                    buffer.delete(0, uri.indexOf(':') + 1);
-                }
-                return schema;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Removes %nn encodings from a string.
-     *
-     * @param encodedStr The encoded String.
-     * @return The decoded String.
-     * @throws FileSystemException if an error occurs.
-     */
-    public static String decode(final String encodedStr) throws FileSystemException {
-        if (encodedStr == null) {
-            return null;
-        }
-        if (encodedStr.indexOf('%') < 0) {
-            return encodedStr;
-        }
-        final StringBuilder buffer = new StringBuilder(encodedStr);
-        decode(buffer, 0, buffer.length());
-        return buffer.toString();
-    }
-
-    /**
-     * Removes %nn encodings from a string.
-     *
-     * @param buffer StringBuilder containing the string to decode.
-     * @param offset The position in the string to start decoding.
-     * @param length The number of characters to decode.
-     * @throws FileSystemException if an error occurs.
-     */
-    public static void decode(final StringBuilder buffer, final int offset, final int length)
-            throws FileSystemException {
-        int index = offset;
-        int count = length;
-        for (; count > 0; count--, index++) {
-            final char ch = buffer.charAt(index);
-            if (ch != '%') {
-                continue;
-            }
-            if (count < 3) {
-                throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
-                        buffer.substring(index, index + count));
-            }
-
-            // Decode
-            final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
-            final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
-            if (dig1 == -1 || dig2 == -1) {
-                throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
-                        buffer.substring(index, index + 3));
-            }
-            final char value = (char) (dig1 << BITS_IN_HALF_BYTE | dig2);
-
-            // Replace
-            buffer.setCharAt(index, value);
-            buffer.delete(index + 1, index + 3);
-            count -= 2;
-        }
-    }
-
-    /**
-     * Encodes and appends a string to a StringBuilder.
-     *
-     * @param buffer The StringBuilder to append to.
-     * @param unencodedValue The String to encode and append.
-     * @param reserved characters to encode.
-     */
-    public static void appendEncoded(final StringBuilder buffer, final String unencodedValue, final char[] reserved) {
-        final int offset = buffer.length();
-        buffer.append(unencodedValue);
-        encode(buffer, offset, unencodedValue.length(), reserved);
-    }
-
-    /**
-     * Encodes a set of reserved characters in a StringBuilder, using the URI %nn encoding. Always encodes % characters.
-     *
-     * @param buffer The StringBuilder to append to.
-     * @param offset The position in the buffer to start encoding at.
-     * @param length The number of characters to encode.
-     * @param reserved characters to encode.
-     */
-    public static void encode(final StringBuilder buffer, final int offset, final int length, final char[] reserved) {
-        int index = offset;
-        int count = length;
-        for (; count > 0; index++, count--) {
-            final char ch = buffer.charAt(index);
-            boolean match = ch == '%';
-            if (reserved != null) {
-                for (int i = 0; !match && i < reserved.length; i++) {
-                    if (ch == reserved[i]) {
-                        match = true;
-                    }
-                }
-            }
-            if (match) {
-                // Encode
-                final char[] digits = { Character.forDigit((ch >> BITS_IN_HALF_BYTE) & LOW_MASK, HEX_BASE),
-                        Character.forDigit(ch & LOW_MASK, HEX_BASE) };
-                buffer.setCharAt(index, '%');
-                buffer.insert(index + 1, digits);
-                index += 2;
-            }
-        }
-    }
-
-    /**
-     * Removes %nn encodings from a string.
-     *
-     * @param decodedStr The decoded String.
-     * @return The encoded String.
-     */
-    public static String encode(final String decodedStr) {
-        return encode(decodedStr, null);
-    }
-
-    /**
-     * Converts "special" characters to their %nn value.
-     *
-     * @param decodedStr The decoded String.
-     * @param reserved Characters to encode.
-     * @return The encoded String
-     */
-    public static String encode(final String decodedStr, final char[] reserved) {
-        if (decodedStr == null) {
-            return null;
-        }
-        final StringBuilder buffer = new StringBuilder(decodedStr);
-        encode(buffer, 0, buffer.length(), reserved);
-        return buffer.toString();
-    }
-
-    /**
-     * Encode an array of Strings.
-     *
-     * @param strings The array of Strings to encode.
-     * @return An array of encoded Strings.
-     */
-    public static String[] encode(final String[] strings) {
-        if (strings == null) {
-            return null;
-        }
-        for (int i = 0; i < strings.length; i++) {
-            strings[i] = encode(strings[i]);
-        }
-        return strings;
-    }
-
-    /**
-     * Decodes the String.
-     *
-     * @param uri The String to decode.
-     * @throws FileSystemException if an error occurs.
-     */
-    public static void checkUriEncoding(final String uri) throws FileSystemException {
-        decode(uri);
-    }
-
-    public static void canonicalizePath(final StringBuilder buffer, final int offset, final int length,
-            final FileNameParser fileNameParser) throws FileSystemException {
-        int index = offset;
-        int count = length;
-        for (; count > 0; count--, index++) {
-            final char ch = buffer.charAt(index);
-            if (ch == '%') {
-                if (count < 3) {
-                    throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
-                            buffer.substring(index, index + count));
-                }
-
-                // Decode
-                final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
-                final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
-                if (dig1 == -1 || dig2 == -1) {
-                    throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
-                            buffer.substring(index, index + 3));
-                }
-                final char value = (char) (dig1 << BITS_IN_HALF_BYTE | dig2);
-
-                final boolean match = value == '%' || fileNameParser.encodeCharacter(value);
-
-                if (match) {
-                    // this is a reserved character, not allowed to decode
-                    index += 2;
-                    count -= 2;
-                    continue;
-                }
-
-                // Replace
-                buffer.setCharAt(index, value);
-                buffer.delete(index + 1, index + 3);
-                count -= 2;
-            } else if (fileNameParser.encodeCharacter(ch)) {
-                // Encode
-                final char[] digits = { Character.forDigit((ch >> BITS_IN_HALF_BYTE) & LOW_MASK, HEX_BASE),
-                        Character.forDigit(ch & LOW_MASK, HEX_BASE) };
-                buffer.setCharAt(index, '%');
-                buffer.insert(index + 1, digits);
-                index += 2;
-            }
-        }
-    }
-
-    /**
-     * Extract the query String from the URI.
-     *
-     * @param name StringBuilder containing the URI.
-     * @return The query string, if any. null otherwise.
-     */
-    public static String extractQueryString(final StringBuilder name) {
-        for (int pos = 0; pos < name.length(); pos++) {
-            if (name.charAt(pos) == '?') {
-                final String queryString = name.substring(pos + 1);
-                name.delete(pos, name.length());
-                return queryString;
-            }
-        }
-
-        return null;
+    private UriParser() {
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileNameParser.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.provider.local;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.provider.AbstractFileNameParser;
 import org.apache.commons.vfs2.provider.UriParser;
 import org.apache.commons.vfs2.provider.VfsComponentContext;
@@ -61,7 +62,7 @@ public abstract class LocalFileNameParser extends AbstractFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme
-        String scheme = UriParser.extractScheme(uri, name);
+        String scheme = UriParser.extractScheme(context.getFileSystemManager().getSchemes(), uri, name);
         if (scheme == null) {
             scheme = "file";
         }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileProvider.java
@@ -27,6 +27,7 @@ import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.provider.AbstractFileProvider;
 import org.apache.commons.vfs2.provider.UriParser;
 
@@ -57,7 +58,7 @@ public class ResourceFileProvider extends AbstractFileProvider {
     public FileObject findFile(final FileObject baseFile, final String uri, final FileSystemOptions fileSystemOptions)
             throws FileSystemException {
         final StringBuilder buf = new StringBuilder(BUFFER_SIZE);
-        UriParser.extractScheme(uri, buf);
+        UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buf);
         final String resourceName = buf.toString();
 
         ClassLoader classLoader = ResourceFileSystemConfigBuilder.getInstance().getClassLoader(fileSystemOptions);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/temp/TemporaryFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/temp/TemporaryFileProvider.java
@@ -25,6 +25,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.provider.AbstractFileProvider;
 import org.apache.commons.vfs2.provider.UriParser;
 import org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider;
@@ -81,7 +82,7 @@ public class TemporaryFileProvider extends AbstractFileProvider implements Compa
             final FileSystemOptions properties) throws FileSystemException {
         // Parse the name
         final StringBuilder buffer = new StringBuilder(uri);
-        final String scheme = UriParser.extractScheme(uri, buffer);
+        final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buffer);
         UriParser.fixSeparators(buffer);
         UriParser.normalisePath(buffer);
         final String path = buffer.toString();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTestCase.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.vfs2.provider;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -24,15 +28,49 @@ import org.junit.Test;
  * @version $Id$
  */
 public class UriParserTestCase {
+    private static final Set<String> schemes = new HashSet<String>();
+
+    @BeforeClass
+    public static void setupSchemes() {
+        schemes.add("ftp");
+        schemes.add("file");
+    }
 
     @Test
-    public void testColonInFileName() {
-        Assert.assertEquals(null, UriParser.extractScheme("some/path/some:file"));
+    public void testColonInFileNameAndNotSupportedScheme() {
+        Assert.assertEquals(null, UriParser.extractSupportedScheme(schemes,"some:file"));
+    }
+    @Test
+    public void testColonInFileNameWithPath() {
+        Assert.assertEquals(null, UriParser.extractSupportedScheme(schemes,"some/path/some:file"));
     }
 
     @Test
     public void testNormalScheme() {
-        Assert.assertEquals("ftp", UriParser.extractScheme("ftp://user:pass@host/some/path/some:file"));
+        Assert.assertEquals("ftp", UriParser.extractSupportedScheme(schemes,"ftp://user:pass@host/some/path/some:file"));
     }
 
+    @Test
+    public void testOneSlashScheme() {
+        Assert.assertEquals("file", UriParser.extractSupportedScheme(schemes,"file:/user:pass@host/some/path/some:file"));
+    }
+
+    @Test
+    public void testColonNotFollowedBySlash() {
+        Assert.assertEquals("file",UriParser.extractSupportedScheme(schemes,"file:user/subdir/some/path/some:file"));
+    }
+
+    @Test
+    public void testNormalSchemeWithBuffer() {
+        StringBuilder buffer = new StringBuilder();
+        UriParser.extractSupportedScheme(schemes,"ftp://user:pass@host/some/path/some:file",buffer);
+        Assert.assertEquals("//user:pass@host/some/path/some:file",buffer.toString());
+    }
+
+    @Test
+    public void testOneSlashSchemeWithBuffer() {
+        StringBuilder buffer = new StringBuilder();
+        UriParser.extractSupportedScheme(schemes,"file:/user:pass@host/some/path/some:file",buffer);
+        Assert.assertEquals("/user:pass@host/some/path/some:file",buffer.toString());
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTestCase.java
@@ -28,49 +28,49 @@ import org.junit.Test;
  * @version $Id$
  */
 public class UriParserTestCase {
-    private static final Set<String> schemes = new HashSet<String>();
+    private static final String[] schemes = new String[2];
 
     @BeforeClass
     public static void setupSchemes() {
-        schemes.add("ftp");
-        schemes.add("file");
+        schemes[0] = "ftp";
+        schemes[1] = "file";
     }
 
     @Test
     public void testColonInFileNameAndNotSupportedScheme() {
-        Assert.assertEquals(null, UriParser.extractSupportedScheme(schemes,"some:file"));
+        Assert.assertEquals(null, UriParser.extractScheme(schemes,"some:file"));
     }
     @Test
     public void testColonInFileNameWithPath() {
-        Assert.assertEquals(null, UriParser.extractSupportedScheme(schemes,"some/path/some:file"));
+        Assert.assertEquals(null, UriParser.extractScheme(schemes,"some/path/some:file"));
     }
 
     @Test
     public void testNormalScheme() {
-        Assert.assertEquals("ftp", UriParser.extractSupportedScheme(schemes,"ftp://user:pass@host/some/path/some:file"));
+        Assert.assertEquals("ftp", UriParser.extractScheme(schemes,"ftp://user:pass@host/some/path/some:file"));
     }
 
     @Test
     public void testOneSlashScheme() {
-        Assert.assertEquals("file", UriParser.extractSupportedScheme(schemes,"file:/user:pass@host/some/path/some:file"));
+        Assert.assertEquals("file", UriParser.extractScheme(schemes,"file:/user:pass@host/some/path/some:file"));
     }
 
     @Test
     public void testColonNotFollowedBySlash() {
-        Assert.assertEquals("file",UriParser.extractSupportedScheme(schemes,"file:user/subdir/some/path/some:file"));
+        Assert.assertEquals("file",UriParser.extractScheme(schemes,"file:user/subdir/some/path/some:file"));
     }
 
     @Test
     public void testNormalSchemeWithBuffer() {
         StringBuilder buffer = new StringBuilder();
-        UriParser.extractSupportedScheme(schemes,"ftp://user:pass@host/some/path/some:file",buffer);
+        UriParser.extractScheme(schemes,"ftp://user:pass@host/some/path/some:file",buffer);
         Assert.assertEquals("//user:pass@host/some/path/some:file",buffer.toString());
     }
 
     @Test
     public void testOneSlashSchemeWithBuffer() {
         StringBuilder buffer = new StringBuilder();
-        UriParser.extractSupportedScheme(schemes,"file:/user:pass@host/some/path/some:file",buffer);
+        UriParser.extractScheme(schemes,"file:/user:pass@host/some/path/some:file",buffer);
         Assert.assertEquals("/user:pass@host/some/path/some:file",buffer.toString());
     }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/test/FileNameTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/test/FileNameTests.java
@@ -17,7 +17,7 @@
 package org.apache.commons.vfs2.provider.local.test;
 
 import java.io.File;
-
+import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.test.AbstractProviderTestCase;

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>43</version>
+    <version>42</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>42</version>
+    <version>43</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,10 @@
       <name>Jose Juan Montiel</name>
       <email>josejuan.montiel -at- gmail.com</email>
     </contributor>
+    <contributor>
+      <name>Otto Fowler</name>
+      <email>otto -at- apache.org</email>
+    </contributor>
   </contributors>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
     <profile>
       <id>include-sandbox</id>
       <modules>
-        <module>sandbox</module>
+        <module>commons-vfs2-sandbox</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
> This issue is not provider dependent

The issue here is that it is possible for file names to have `:` in them for some providers ( such as FTP).  This causes an issue
because the code wants evaluate a string which may be a name or an url with a scheme to extract, and does so by
searching for `:` and assuming everything to the left is the scheme.

### From Jira:
The code wants to support a string the may be a url or may not be at the same time.
The issue is, that no matter what we do we can never know if the ':' is the scheme marker or part of the file name.
each scheme by definition supports a different scheme part ( the part after the : ) and some don't even have one.
Add to this, that the scheme is used in the system to map to a provider, and those can be registered with whatever scheme a developer wants.

My proposal is to limit the recognized scheme's returned by extractScheme to those registered in the system.  I believe this is the most correct way to do this.
- it is only way to be sure that it is a scheme and not just a ':'
- the system can only support registered schemes anyway

-----------

So this PR introduces a new method to the URLParser which will extract the scheme using comparison to the schemes registered in the system currently.


### Questions for review
- Is the scope of this fix sufficient, or does the extractSchema() call need to be completely removed and replaced and all access changed?  ( I think this will need to be done )
- If a public method is removed and replaced, how does this project handle that?