### PR TITLE
VFS-614 MonitorInputStream should not close the stream in "read"

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
@@ -93,9 +93,6 @@ public class MonitorInputStream extends BufferedInputStream {
             atomicCount.addAndGet(nread);
             return nread;
         }
-
-        // End-of-stream
-        close();
         return EOF_CHAR;
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
@@ -1,0 +1,72 @@
+package org.apache.commons.vfs2.provider;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * {@code DefaultFileContentTest} tests for bug-VFS-614.
+ * This bug involves the stream implementation closing the stream after reading to the end of the
+ * buffer, which broke marking.
+ */
+public class DefaultFileContentTest {
+    private static final String expected = "testing";
+
+    @Test
+    public void testMarkingWorks() throws Exception {
+        File temp = File.createTempFile("temp-file-name", ".tmp");
+        FileSystemManager fileSystemManager = VFS.getManager();
+
+        try (FileObject file = fileSystemManager.resolveFile(temp.getAbsolutePath())) {
+            try (OutputStream outputStream = file.getContent().getOutputStream()) {
+                outputStream.write(expected.getBytes());
+                outputStream.flush();
+            }
+            try (InputStream stream = file.getContent().getInputStream()) {
+                if (stream.markSupported()) {
+                    for (int i = 0; i < 10; i++) {
+                        stream.mark(0);
+                        byte[] data = new byte[100];
+                        stream.read(data, 0, 7);
+                        Assert.assertEquals(expected, new String(data).trim());
+                        stream.reset();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMarkingWhenReadingEOS() throws Exception {
+        File temp = File.createTempFile("temp-file-name", ".tmp");
+        FileSystemManager fileSystemManager = VFS.getManager();
+
+        try (FileObject file = fileSystemManager.resolveFile(temp.getAbsolutePath())) {
+            try (OutputStream outputStream = file.getContent().getOutputStream()) {
+                outputStream.write(expected.getBytes());
+                outputStream.flush();
+            }
+            try (InputStream stream = file.getContent().getInputStream()) {
+                int readCount = 0;
+                if (stream.markSupported()) {
+                    for (int i = 0; i < 10; i++) {
+                        stream.mark(0);
+                        byte[] data = new byte[100];
+                        readCount = stream.read(data, 0, 7);
+                        Assert.assertEquals(readCount, 7);
+                        Assert.assertEquals(expected, new String(data).trim());
+                        readCount = stream.read(data, 8, 10);
+                        Assert.assertEquals(readCount, -1);
+                        stream.reset();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
MonitorInputStream exposes that it supports marking by way of it's super BufferedInputStream.  
Because it closes itself after a read which encounters the end of the stream however ( which is contrary to BufferedInputStream ) it breaks marking functionality.

This PR removes to the close() call on read after EOF, making the MonitorInputStream behave as BufferedInputStream, and as one would expect a Stream that supports marking would.  Tests are also added.