### PR TITLE
[VFS-655] Force osgi optional Import-Package for optional dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@
     <version.checkstyle>2.17</version.checkstyle>
     <!-- make sure bundle plugin has dependency informations for 'optional' -->
     <commons.osgi.excludeDependencies />
+	<commons.osgi.import>
+		org.apache.hadoop.*;resolution:=optional,
+		org.apache.jackrabbit.*;resolution:=optional,
+		org.apache.tools.ant.*;resolution:=optional,
+		org.apache.commons.httpclient.*;resolution:=optional,
+		*
+	</commons.osgi.import>
     <!-- Newer versions of clirr throw an NPE building the site -->
     <commons.clirr.version>2.6</commons.clirr.version>
     <!-- Avoid warnings about being unable to find jars during site building -->


### PR DESCRIPTION
For some reasons "Import-Package" section of the MANIFEST.MF is not "optional" for some optional dependencies

Maybe caused by maven-bundle-plugin issue ? (like this https://issues.apache.org/jira/browse/FELIX-4626)

This proposed fix is to force optional for these dependencies