### PR TITLE
VFS-360: Migrate to HttpComponent HttpClient

### DIFF
--- a/commons-vfs2-examples/README.md
+++ b/commons-vfs2-examples/README.md
@@ -1,0 +1,18 @@
+# Test Provider(s) with the Shell
+
+## Build modules in the parent folder
+
+    mvn clean install
+
+## Test `http` and `https` providers
+
+    mvn -Pshell -Dhttp
+
+## Test `http4` and `http4s` providers
+
+    mvn -Pshell -Dhttp4
+
+## Test `http`, `https`, `http4` and `http4s` providers together
+
+    mvn -Pshell -Dhttp -Dhttp4
+

--- a/commons-vfs2-examples/README.md
+++ b/commons-vfs2-examples/README.md
@@ -1,3 +1,20 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 # Test Provider(s) with the Shell
 
 ## Build modules in the parent folder

--- a/commons-vfs2-examples/pom.xml
+++ b/commons-vfs2-examples/pom.xml
@@ -51,16 +51,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <optional>true</optional>
@@ -83,5 +73,68 @@
       </resource>
     </resources>
   </build>
+
+  <profiles>
+
+    <profile>
+      <id>shell</id>
+      <build>
+        <defaultGoal>validate</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <mainClass>org.apache.commons.vfs2.example.Shell</mainClass>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>with-http</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>http</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>with-http4</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>http4</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+  </profiles>
 
 </project>

--- a/commons-vfs2-examples/pom.xml
+++ b/commons-vfs2-examples/pom.xml
@@ -56,6 +56,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <optional>true</optional>

--- a/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
+++ b/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
@@ -56,15 +56,19 @@ public final class Shell {
         mgr = VFS.getManager();
 
         // VFS-360: Keep this manual init block until http4 becomes part of standard providers.
+        boolean httpClient4Available = false;
         try {
             Class.forName("org.apache.http.client.HttpClient");
+            httpClient4Available = true;
             final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();
             if (!manager.hasProvider("http4")) {
-                manager.addProvider("http4", (FileProvider) Class
-                        .forName("org.apache.commons.vfs2.provider.http4.Http4FileProvider").newInstance());
+                manager.addProvider("http4", (FileProvider) Class.forName("org.apache.commons.vfs2.provider.http4.Http4FileProvider").newInstance());
+                manager.addProvider("http4s", (FileProvider) Class.forName("org.apache.commons.vfs2.provider.http4s.Http4sFileProvider").newInstance());
             }
         } catch (Exception e) {
-            // HTTP4 / HttpClient v4 unavailable.
+            if (httpClient4Available) {
+                e.printStackTrace();
+            }
         }
 
         cwd = mgr.toFileObject(new File(System.getProperty("user.dir")));

--- a/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
+++ b/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
@@ -55,7 +55,7 @@ public final class Shell {
     private Shell() throws IOException {
         mgr = VFS.getManager();
 
-        // VFS-360: Keep this manual init block until http4 becomes part of standard providers.
+        // TODO: VFS-360 - Remove this manual registration of http4 once http4 becomes part of standard providers.
         boolean httpClient4Available = false;
         try {
             Class.forName("org.apache.http.client.HttpClient");

--- a/commons-vfs2-sandbox/pom.xml
+++ b/commons-vfs2-sandbox/pom.xml
@@ -55,6 +55,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
       <optional>true</optional>

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -75,6 +75,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
       <optional>true</optional>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/providers.xml
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/providers.xml
@@ -63,10 +63,6 @@
         <scheme name="https"/>
         <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
     </provider>
-    <provider class-name="org.apache.commons.vfs2.provider.http4.Http4FileProvider">
-        <scheme name="http4"/>
-        <if-available class-name="org.apache.http.client.HttpClient"/>
-    </provider>
     <provider class-name="org.apache.commons.vfs2.provider.sftp.SftpFileProvider">
         <scheme name="sftp"/>
         <if-available class-name="javax.crypto.Cipher"/>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/providers.xml
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/providers.xml
@@ -63,6 +63,10 @@
         <scheme name="https"/>
         <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
     </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.http4.Http4FileProvider">
+        <scheme name="http4"/>
+        <if-available class-name="org.apache.http.client.HttpClient"/>
+    </provider>
     <provider class-name="org.apache.commons.vfs2.provider.sftp.SftpFileProvider">
         <scheme name="sftp"/>
         <if-available class-name="javax.crypto.Cipher"/>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileName.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileName.java
@@ -16,23 +16,23 @@
  */
 package org.apache.commons.vfs2.provider;
 
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.URIUtil;
+import java.net.URISyntaxException;
+
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.util.URIUtils;
 
 /**
- * A file name that represents URL.
- * @deprecated Use {@link GenericURLFileName} as it doesn't depend on Http Client v3 API directly.
+ * Generic file name that represents a URL.
  */
-@Deprecated
-public class URLFileName extends GenericFileName {
+public class GenericURLFileName extends GenericFileName {
+
     private static final int BUFFER_SIZE = 250;
 
     private final String queryString;
 
-    public URLFileName(final String scheme, final String hostName, final int port, final int defaultPort,
+    public GenericURLFileName(final String scheme, final String hostName, final int port, final int defaultPort,
             final String userName, final String password, final String path, final FileType type,
             final String queryString) {
         super(scheme, hostName, port, defaultPort, userName, password, path, type);
@@ -67,22 +67,23 @@ public class URLFileName extends GenericFileName {
      *
      * @param charset the charset used for the path encoding
      * @return The encoded path.
-     * @throws URIException If an error occurs encoding the URI.
+     * @throws URISyntaxException If an error occurs encoding the URI.
      * @throws FileSystemException If some other error occurs.
      */
-    public String getPathQueryEncoded(final String charset) throws URIException, FileSystemException {
+    public String getPathQueryEncoded(final String charset) throws URISyntaxException, FileSystemException {
         if (getQueryString() == null) {
             if (charset != null) {
-                return URIUtil.encodePath(getPathDecoded(), charset);
+                return URIUtils.encodePath(getPathDecoded(), charset);
+            } else {
+                return URIUtils.encodePath(getPathDecoded());
             }
-            return URIUtil.encodePath(getPathDecoded());
         }
 
         final StringBuilder sb = new StringBuilder(BUFFER_SIZE);
         if (charset != null) {
-            sb.append(URIUtil.encodePath(getPathDecoded(), charset));
+            sb.append(URIUtils.encodePath(getPathDecoded(), charset));
         } else {
-            sb.append(URIUtil.encodePath(getPathDecoded()));
+            sb.append(URIUtils.encodePath(getPathDecoded()));
         }
         sb.append("?");
         sb.append(getQueryString());
@@ -98,7 +99,7 @@ public class URLFileName extends GenericFileName {
      */
     @Override
     public FileName createName(final String absPath, final FileType type) {
-        return new URLFileName(getScheme(), getHostName(), getPort(), getDefaultPort(), getUserName(), getPassword(),
+        return new GenericURLFileName(getScheme(), getHostName(), getPort(), getDefaultPort(), getUserName(), getPassword(),
                 absPath, type, getQueryString());
     }
 
@@ -127,9 +128,9 @@ public class URLFileName extends GenericFileName {
      * @param charset The character set.
      * @return The encoded URI
      * @throws FileSystemException if some other exception occurs.
-     * @throws URIException if an exception occurs encoding the URI.
+     * @throws URISyntaxException if an exception occurs encoding the URI.
      */
-    public String getURIEncoded(final String charset) throws FileSystemException, URIException {
+    public String getURIEncoded(final String charset) throws FileSystemException, URISyntaxException {
         final StringBuilder sb = new StringBuilder(BUFFER_SIZE);
         appendRootUri(sb, true);
         sb.append(getPathQueryEncoded(charset));

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
@@ -21,14 +21,13 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 
 /**
- * Implementation for any url based filesystem.
+ * Generic implementation for any url based filesystem.
  * <p>
  * Parses the url into user/password/host/port/path/queryString.
- * @deprecated Use {@link GenericURLFileNameParser} as it doesn't depend on Http Client v3 API directly.
  */
-@Deprecated
-public class URLFileNameParser extends HostFileNameParser {
-    public URLFileNameParser(final int defaultPort) {
+public class GenericURLFileNameParser extends HostFileNameParser {
+
+    public GenericURLFileNameParser(final int defaultPort) {
         super(defaultPort);
     }
 
@@ -55,7 +54,7 @@ public class URLFileNameParser extends HostFileNameParser {
         final FileType fileType = UriParser.normalisePath(name);
         final String path = name.toString();
 
-        return new URLFileName(auth.getScheme(), auth.getHostName(), auth.getPort(), getDefaultPort(),
+        return new GenericURLFileName(auth.getScheme(), auth.getHostName(), auth.getPort(), getDefaultPort(),
                 auth.getUserName(), auth.getPassword(), path, fileType, queryString);
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
@@ -21,7 +21,7 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 
 /**
- * Generic implementation for any url based filesystem.
+ * Generic implementation for any url based filesystem, without depending a specific library.
  * <p>
  * Parses the url into user/password/host/port/path/queryString.
  */

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.io.IOException;
+
+import org.apache.commons.vfs2.FileContent;
+import org.apache.commons.vfs2.FileContentInfo;
+import org.apache.commons.vfs2.FileContentInfoFactory;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.impl.DefaultFileContentInfo;
+import org.apache.commons.vfs2.util.FileObjectUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+
+/**
+ * Creates FileContentInfo instances for HTTP4.
+ */
+public class Http4FileContentInfoFactory implements FileContentInfoFactory {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public FileContentInfo create(final FileContent fileContent) throws FileSystemException {
+        String contentMimeType = null;
+        String contentCharset = null;
+
+        try (final Http4FileObject<Http4FileSystem> http4File = (Http4FileObject<Http4FileSystem>) FileObjectUtils
+                .getAbstractFileObject(fileContent.getFile())) {
+            final HttpResponse lastHeadResponse = http4File.getLastHeadResponse();
+
+            final Header header = lastHeadResponse.getFirstHeader("Content-Type");
+
+            if (header != null) {
+                final ContentType contentType = ContentType.parse(header.getValue());
+                contentMimeType = contentType.getMimeType();
+
+                if (contentType.getCharset() != null) {
+                    contentCharset = contentType.getCharset().name();
+                }
+            }
+
+            return new DefaultFileContentInfo(contentMimeType, contentCharset);
+        } catch (final IOException e) {
+            throw new FileSystemException(e);
+        }
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
@@ -30,7 +30,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.protocol.HTTP;
 
 /**
- * Creates FileContentInfo instances for HTTP4.
+ * Creates <code>FileContentInfoFactory</code> instances for http4 provider.
  */
 public class Http4FileContentInfoFactory implements FileContentInfoFactory {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileContentInfoFactory.java
@@ -27,6 +27,7 @@ import org.apache.commons.vfs2.util.FileObjectUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
 
 /**
  * Creates FileContentInfo instances for HTTP4.
@@ -43,7 +44,7 @@ public class Http4FileContentInfoFactory implements FileContentInfoFactory {
                 .getAbstractFileObject(fileContent.getFile())) {
             final HttpResponse lastHeadResponse = http4File.getLastHeadResponse();
 
-            final Header header = lastHeadResponse.getFirstHeader("Content-Type");
+            final Header header = lastHeadResponse.getFirstHeader(HTTP.CONTENT_TYPE);
 
             if (header != null) {
                 final ContentType contentType = ContentType.parse(header.getValue());

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import org.apache.commons.vfs2.provider.FileNameParser;
+import org.apache.commons.vfs2.provider.URLFileNameParser;
+
+/**
+ * Implementation for http4. set default port to 80
+ */
+public class Http4FileNameParser extends URLFileNameParser {
+
+    private static final int DEFAULT_PORT = 80;
+
+    private static final Http4FileNameParser INSTANCE = new Http4FileNameParser();
+
+    public Http4FileNameParser() {
+        super(DEFAULT_PORT);
+    }
+
+    public static FileNameParser getInstance() {
+        return INSTANCE;
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
@@ -17,12 +17,12 @@
 package org.apache.commons.vfs2.provider.http4;
 
 import org.apache.commons.vfs2.provider.FileNameParser;
-import org.apache.commons.vfs2.provider.URLFileNameParser;
+import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
 
 /**
  * Implementation for http4. set default port to 80
  */
-public class Http4FileNameParser extends URLFileNameParser {
+public class Http4FileNameParser extends GenericURLFileNameParser {
 
     private static final int DEFAULT_PORT = 80;
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileNameParser.java
@@ -20,7 +20,7 @@ import org.apache.commons.vfs2.provider.FileNameParser;
 import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
 
 /**
- * Implementation for http4. set default port to 80.
+ * <code>FileNameParser</code> implementation for http4 provider, setting default port to 80.
  */
 public class Http4FileNameParser extends GenericURLFileNameParser {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -28,7 +28,7 @@ import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.RandomAccessContent;
 import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.AbstractFileObject;
-import org.apache.commons.vfs2.provider.URLFileName;
+import org.apache.commons.vfs2.provider.GenericURLFileName;
 import org.apache.commons.vfs2.util.RandomAccessMode;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -157,7 +157,7 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
         String pathEncoded = null;
 
         try {
-            pathEncoded = ((URLFileName) getName()).getPathQueryEncoded(getUrlCharset());
+            pathEncoded = ((GenericURLFileName) getName()).getPathQueryEncoded(getUrlCharset());
         } catch (Exception e) {
             // TODO: which exception is proper?
             throw new RuntimeException(e.getMessage(), e);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -50,17 +50,42 @@ import org.apache.http.protocol.HTTP;
  */
 public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObject<FS> {
 
+    /**
+     * URL charset string.
+     */
     private final String urlCharset;
 
+    /**
+     * Internal URI mapped to this <code>FileObject</code>.
+     * For example, the internal URI of <code>http4://example.com/a.txt</code> is <code>http://example.com/a.txt</code>.
+     */
     private final URI internalURI;
 
+    /**
+     * The last executed HEAD <code>HttpResponse</code> object.
+     */
     private HttpResponse lastHeadResponse;
 
+    /**
+     * Construct <code>Http4FileObject</code>.
+     * @param name file name
+     * @param fileSystem file system
+     * @throws FileSystemException if any error occurs
+     * @throws URISyntaxException if given file name cannot be converted to a URI due to URI syntax error
+     */
     protected Http4FileObject(final AbstractFileName name, final FS fileSystem)
             throws FileSystemException, URISyntaxException {
         this(name, fileSystem, Http4FileSystemConfigBuilder.getInstance());
     }
 
+    /**
+     * Construct <code>Http4FileObject</code>.
+     * @param name file name
+     * @param fileSystem file system
+     * @param builder <code>Http4FileSystemConfigBuilder</code> object
+     * @throws FileSystemException if any error occurs
+     * @throws URISyntaxException if given file name cannot be converted to a URI due to URI syntax error
+     */
     protected Http4FileObject(final AbstractFileName name, final FS fileSystem,
             final Http4FileSystemConfigBuilder builder) throws FileSystemException, URISyntaxException {
         super(name, fileSystem);
@@ -159,14 +184,28 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
         lastHeadResponse = null;
     }
 
+    /**
+     * Return URL charset string.
+     * @return URL charset string
+     */
     protected String getUrlCharset() {
         return urlCharset;
     }
 
+    /**
+     * Return the internal <code>URI</code> object mapped to this file object.
+     * @return the internal <code>URI</code> object mapped to this file object
+     * @throws FileSystemException if any error occurs
+     */
     protected URI getInternalURI() throws FileSystemException {
         return internalURI;
     }
 
+    /**
+     * Return the last executed HEAD <code>HttpResponse</code> object.
+     * @return the last executed HEAD <code>HttpResponse</code> object
+     * @throws IOException if IO error occurs
+     */
     HttpResponse getLastHeadResponse() throws IOException {
         if (lastHeadResponse != null) {
             return lastHeadResponse;
@@ -175,6 +214,12 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
         return executeHttpUriRequest(new HttpHead(getInternalURI()));
     }
 
+    /**
+     * Execute the request using the given {@code httpRequest} and return a <code>HttpResponse</code> from the execution.
+     * @param httpRequest <code>HttpUriRequest</code> object
+     * @return <code>HttpResponse</code> from the execution
+     * @throws IOException if IO error occurs
+     */
     HttpResponse executeHttpUriRequest(final HttpUriRequest httpRequest) throws IOException {
         final HttpClient httpClient = getAbstractFileSystem().getHttpClient();
         final HttpClientContext httpClientContext = getAbstractFileSystem().getHttpClientContext();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -44,6 +44,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.DateUtils;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.protocol.HTTP;
+import org.apache.http.util.EntityUtils;
 
 /**
  * A file object backed by Apache HttpComponents HttpClient.
@@ -94,7 +95,9 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
             }
         } finally {
             // Some web servers send body entity in HEAD request, so let's consume it for safety, especially in Keep-Alive mode.
-            consumeFullHttpEntityQuietly(entity);
+            if (entity != null) {
+                EntityUtils.consumeQuietly(entity);
+            }
         }
     }
 
@@ -189,15 +192,5 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
 
     HttpResponse getLastHeadResponse() {
         return lastHeadResponse;
-    }
-
-    private void consumeFullHttpEntityQuietly(final HttpEntity httpEntity) {
-        if (httpEntity != null) {
-            try (InputStream input = httpEntity.getContent()) {
-                final byte[] buffer = new byte[BUFFER_SIZE];
-                while (-1 != input.read(buffer));
-            } catch (IOException ignore) {
-            }
-        }
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import org.apache.commons.vfs2.FileContentInfoFactory;
+import org.apache.commons.vfs2.FileNotFoundException;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.RandomAccessContent;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.apache.commons.vfs2.provider.URLFileName;
+import org.apache.commons.vfs2.util.RandomAccessMode;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.DateUtils;
+import org.apache.http.client.utils.URIUtils;
+
+public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObject<FS> {
+
+    private final String urlCharset;
+
+    private HttpResponse lastHeadResponse;
+
+    protected Http4FileObject(final AbstractFileName name, final FS fileSystem) {
+        this(name, fileSystem, Http4FileSystemConfigBuilder.getInstance());
+    }
+
+    protected Http4FileObject(final AbstractFileName name, final FS fileSystem,
+            final Http4FileSystemConfigBuilder builder) {
+        super(name, fileSystem);
+        final FileSystemOptions fileSystemOptions = fileSystem.getFileSystemOptions();
+        urlCharset = builder.getUrlCharset(fileSystemOptions);
+    }
+
+    @Override
+    protected FileType doGetType() throws Exception {
+        final HttpHead headRequest = new HttpHead(getURI());
+        lastHeadResponse = executeHttpUriRequest(headRequest);
+        final int status = lastHeadResponse.getStatusLine().getStatusCode();
+
+        if (status == HttpStatus.SC_OK
+                || status == HttpStatus.SC_METHOD_NOT_ALLOWED /* method is not allowed, but resource exist */) {
+            return FileType.FILE;
+        } else if (status == HttpStatus.SC_NOT_FOUND || status == HttpStatus.SC_GONE) {
+            return FileType.IMAGINARY;
+        } else {
+            throw new FileSystemException("vfs.provider.http/head.error", getName(), Integer.valueOf(status));
+        }
+    }
+
+    @Override
+    protected long doGetContentSize() throws Exception {
+        if (lastHeadResponse == null) {
+            return 0L;
+        }
+
+        final Header header = lastHeadResponse.getFirstHeader("Content-Length");
+
+        if (header == null) {
+            // Assume 0 content-length
+            return 0;
+        }
+
+        return Long.parseLong(header.getValue());
+    }
+
+    @Override
+    protected long doGetLastModifiedTime() throws Exception {
+        if (lastHeadResponse == null) {
+            throw new FileSystemException("vfs.provider.http/last-modified.error", getName());
+        }
+
+        final Header header = lastHeadResponse.getFirstHeader("last-modified");
+
+        if (header == null) {
+            throw new FileSystemException("vfs.provider.http/last-modified.error", getName());
+        }
+
+        return DateUtils.parseDate(header.getValue()).getTime();
+    }
+
+
+    @Override
+    protected InputStream doGetInputStream() throws Exception {
+        final HttpGet getRequest = new HttpGet(getURI());
+        final HttpResponse httpResponse = executeHttpUriRequest(getRequest);
+        final int status = httpResponse.getStatusLine().getStatusCode();
+
+        if (status == HttpStatus.SC_NOT_FOUND) {
+            throw new FileNotFoundException(getName());
+        }
+
+        if (status != HttpStatus.SC_OK) {
+            throw new FileSystemException("vfs.provider.http/get.error", getName(), Integer.valueOf(status));
+        }
+
+        return new MonitoredHttpResponseContentInputStream(httpResponse);
+    }
+
+    @Override
+    protected RandomAccessContent doGetRandomAccessContent(final RandomAccessMode mode) throws Exception {
+        return new Http4RandomAccessContent<>(this, mode);
+    }
+
+    @Override
+    protected String[] doListChildren() throws Exception {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    protected boolean doIsWriteable() throws Exception {
+        return false;
+    }
+
+    @Override
+    protected FileContentInfoFactory getFileContentInfoFactory() {
+        return new Http4FileContentInfoFactory();
+    }
+
+    @Override
+    protected void doDetach() throws Exception {
+        lastHeadResponse = null;
+    }
+
+    protected String getUrlCharset() {
+        return urlCharset;
+    }
+
+    protected URI getURI() throws FileSystemException {
+        String pathEncoded = null;
+
+        try {
+            pathEncoded = ((URLFileName) getName()).getPathQueryEncoded(getUrlCharset());
+        } catch (Exception e) {
+            // TODO: which exception is proper?
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        return URIUtils.resolve(getAbstractFileSystem().getBaseURI(), pathEncoded);
+    }
+
+    protected HttpResponse executeHttpUriRequest(final HttpUriRequest httpRequest)
+            throws ClientProtocolException, IOException {
+        final HttpClient httpClient = getAbstractFileSystem().getHttpClient();
+        final HttpClientContext httpClientContext = getAbstractFileSystem().getHttpClientContext();
+        return httpClient.execute(httpRequest, httpClientContext);
+    }
+
+    HttpResponse getLastHeadResponse() {
+        return lastHeadResponse;
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -43,6 +43,11 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.DateUtils;
 import org.apache.http.client.utils.URIUtils;
 
+/**
+ * A file object backed by Apache HttpComponents HttpClient.
+ *
+ * @param <FS> An {@link Http4FileSystem} subclass
+ */
 public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObject<FS> {
 
     private final String urlCharset;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileObject.java
@@ -34,7 +34,6 @@ import org.apache.commons.vfs2.util.RandomAccessMode;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -73,8 +72,7 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
 
     @Override
     protected FileType doGetType() throws Exception {
-        final HttpHead headRequest = new HttpHead(getInternalURI());
-        lastHeadResponse = executeHttpUriRequest(headRequest);
+        lastHeadResponse = executeHttpUriRequest(new HttpHead(getInternalURI()));
         final int status = lastHeadResponse.getStatusLine().getStatusCode();
 
         if (status == HttpStatus.SC_OK
@@ -169,14 +167,18 @@ public class Http4FileObject<FS extends Http4FileSystem> extends AbstractFileObj
         return internalURI;
     }
 
-    protected HttpResponse executeHttpUriRequest(final HttpUriRequest httpRequest)
-            throws ClientProtocolException, IOException {
+    HttpResponse getLastHeadResponse() throws IOException {
+        if (lastHeadResponse != null) {
+            return lastHeadResponse;
+        }
+
+        return executeHttpUriRequest(new HttpHead(getInternalURI()));
+    }
+
+    HttpResponse executeHttpUriRequest(final HttpUriRequest httpRequest) throws IOException {
         final HttpClient httpClient = getAbstractFileSystem().getHttpClient();
         final HttpClientContext httpClientContext = getAbstractFileSystem().getHttpClientContext();
         return httpClient.execute(httpRequest, httpClientContext);
     }
 
-    HttpResponse getLastHeadResponse() {
-        return lastHeadResponse;
-    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
@@ -143,7 +143,7 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                 .setDefaultHeaders(defaultHeaders)
                 .setDefaultCookieStore(createDefaultCookieStore(builder, fileSystemOptions));
 
-        if (builder.getFollowRedirect(fileSystemOptions)) {
+        if (!builder.getFollowRedirect(fileSystemOptions)) {
             httpClientBuilder.disableRedirectHandling();
         }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
+import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
+import org.apache.http.Header;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHeader;
+
+/**
+ * An HTTP provider that uses HttpComponents HttpClient.
+ */
+public class Http4FileProvider extends AbstractOriginatingFileProvider {
+
+    /** Authenticator information. */
+    static final UserAuthenticationData.Type[] AUTHENTICATOR_TYPES =
+            new UserAuthenticationData.Type[] {
+                    UserAuthenticationData.USERNAME,
+                    UserAuthenticationData.PASSWORD
+                    };
+
+    static final Collection<Capability> capabilities =
+            Collections.unmodifiableCollection(
+                    Arrays.asList(
+                            Capability.GET_TYPE,
+                            Capability.READ_CONTENT,
+                            Capability.URI,
+                            Capability.GET_LAST_MODIFIED,
+                            Capability.ATTRIBUTES,
+                            Capability.RANDOM_ACCESS_READ,
+                            Capability.DIRECTORY_READ_CONTENT
+                            )
+                    );
+
+    /**
+     * Constructs a new provider.
+     */
+    public Http4FileProvider() {
+        super();
+        setFileNameParser(Http4FileNameParser.getInstance());
+    }
+
+    @Override
+    public FileSystemConfigBuilder getConfigBuilder() {
+        return Http4FileSystemConfigBuilder.getInstance();
+    }
+
+    @Override
+    public Collection<Capability> getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    protected FileSystem doCreateFileSystem(FileName name, FileSystemOptions fileSystemOptions)
+            throws FileSystemException {
+        final GenericFileName rootName = (GenericFileName) name;
+
+        UserAuthenticationData authData = null;
+        HttpClient httpClient = null;
+        HttpClientContext httpClientContext = null;
+
+        try {
+            authData = UserAuthenticatorUtils.authenticate(fileSystemOptions, AUTHENTICATOR_TYPES);
+            httpClientContext = createHttpClientContext(rootName, authData);
+            httpClient = createHttpClient(rootName, fileSystemOptions);
+        } finally {
+            UserAuthenticatorUtils.cleanup(authData);
+        }
+
+        return new Http4FileSystem(rootName, fileSystemOptions, httpClient, httpClientContext);
+    }
+
+    protected HttpClient createHttpClient(final GenericFileName rootName, final FileSystemOptions fileSystemOptions) {
+        return createHttpClient(Http4FileSystemConfigBuilder.getInstance(), rootName, fileSystemOptions);
+    }
+
+    protected HttpClient createHttpClient(final Http4FileSystemConfigBuilder builder, final GenericFileName rootName,
+            final FileSystemOptions fileSystemOptions) {
+
+        final List<Header> defaultHeaders = new ArrayList<>();
+        defaultHeaders.add(new BasicHeader("User-Agent", builder.getUserAgent(fileSystemOptions)));
+
+        final HttpClientBuilder httpClientBuilder =
+                HttpClients.custom()
+                .setConnectionManager(createConnectionManager(builder, fileSystemOptions))
+                .setDefaultRequestConfig(createDefaultRequestConfig(builder, fileSystemOptions))
+                .setDefaultHeaders(defaultHeaders);
+
+        if (builder.getFollowRedirect(fileSystemOptions)) {
+            httpClientBuilder.disableRedirectHandling();
+        }
+
+        return httpClientBuilder.build();
+    }
+
+    protected HttpClientContext createHttpClientContext(final GenericFileName rootName,
+            final UserAuthenticationData authData) {
+        final String username = UserAuthenticatorUtils.toString(UserAuthenticatorUtils.getData(authData,
+                UserAuthenticationData.USERNAME, UserAuthenticatorUtils.toChar(rootName.getUserName())));
+        final String password = UserAuthenticatorUtils.toString(UserAuthenticatorUtils.getData(authData,
+                UserAuthenticationData.PASSWORD, UserAuthenticatorUtils.toChar(rootName.getPassword())));
+
+        final CredentialsProvider credsProvider = new BasicCredentialsProvider();
+
+        if (username != null && !username.isEmpty()) {
+            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), rootName.getPort()),
+                    new UsernamePasswordCredentials(username, password));
+        }
+
+        final HttpClientContext clientContext = HttpClientContext.create();
+        clientContext.setCredentialsProvider(credsProvider);
+
+        return clientContext;
+    }
+
+    private HttpClientConnectionManager createConnectionManager(final Http4FileSystemConfigBuilder builder,
+            final FileSystemOptions fileSystemOptions) {
+        final PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+        connManager.setMaxTotal(builder.getMaxTotalConnections(fileSystemOptions));
+        connManager.setDefaultMaxPerRoute(builder.getMaxConnectionsPerRoute(fileSystemOptions));
+        return connManager;
+    }
+
+    private RequestConfig createDefaultRequestConfig(final Http4FileSystemConfigBuilder builder,
+            final FileSystemOptions fileSystemOptions) {
+        return RequestConfig.custom()
+                .setSocketTimeout(builder.getSoTimeout(fileSystemOptions))
+                .setConnectTimeout(builder.getConnectionTimeout(fileSystemOptions))
+                .build();
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
@@ -37,9 +37,6 @@ import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
 import org.apache.http.ConnectionReuseStrategy;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
@@ -65,7 +62,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HTTP;
-import org.apache.http.protocol.HttpRequestExecutor;
 
 /**
  * HTTP4 provider that uses HttpComponents HttpClient.
@@ -153,7 +149,6 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                 .setRoutePlanner(createHttpRoutePlanner(builder, fileSystemOptions))
                 .setConnectionManager(createConnectionManager(builder, fileSystemOptions))
                 .setConnectionReuseStrategy(connectionReuseStrategy)
-                .setRequestExecutor(new HeadBodyAcceptingHttpRequestExecutor())
                 .setDefaultRequestConfig(createDefaultRequestConfig(builder, fileSystemOptions))
                 .setDefaultHeaders(defaultHeaders)
                 .setDefaultCookieStore(createDefaultCookieStore(builder, fileSystemOptions));
@@ -288,17 +283,4 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
         return cookieStore;
     }
 
-    /**
-     * Some web servers send body in HEAD response, which must be consumed in Keep-Alive mode.
-     * Otherwise, the next request-response can be polluted from unread response data in previous HEAD response.
-     */
-    private static class HeadBodyAcceptingHttpRequestExecutor extends HttpRequestExecutor {
-
-        @Override
-        protected boolean canResponseHaveBody(final HttpRequest request, final HttpResponse response) {
-            final int status = response.getStatusLine().getStatusCode();
-            return status >= HttpStatus.SC_OK && status != HttpStatus.SC_NO_CONTENT
-                    && status != HttpStatus.SC_NOT_MODIFIED && status != HttpStatus.SC_RESET_CONTENT;
-        }
-    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -35,7 +35,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
  */
 public class Http4FileSystem extends AbstractFileSystem {
 
-    private final URI baseURI;
+    private final URI internalBaseURI;
     private final HttpClient httpClient;
     private final HttpClientContext httpClientContext;
 
@@ -45,12 +45,13 @@ public class Http4FileSystem extends AbstractFileSystem {
 
         final String rootURI = getRootURI();
         final int offset = rootURI.indexOf(':');
-        final String scheme = rootURI.substring(0, offset);
+        final char lastCharOfScheme = (offset > 0) ? rootURI.charAt(offset - 1) : 0;
 
-        if ("http4s".equals(scheme)) {
-            this.baseURI = URI.create("https" + rootURI.substring(offset));
+        // if scheme is 'http*s' or 'HTTP*S', then the internal base URI should be 'https'. 'http' otherwise.
+        if (lastCharOfScheme == 's' || lastCharOfScheme == 'S') {
+            this.internalBaseURI = URI.create("https" + rootURI.substring(offset));
         } else {
-            this.baseURI = URI.create("http" + rootURI.substring(offset));
+            this.internalBaseURI = URI.create("http" + rootURI.substring(offset));
         }
 
         this.httpClient = httpClient;
@@ -86,7 +87,7 @@ public class Http4FileSystem extends AbstractFileSystem {
         return httpClientContext;
     }
 
-    protected URI getBaseURI() {
-        return baseURI;
+    protected URI getInternalBaseURI() {
+        return internalBaseURI;
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -31,14 +31,32 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 /**
- * HTTP4 file system.
+ * http4 file system.
  */
 public class Http4FileSystem extends AbstractFileSystem {
 
+    /**
+     * Internal base URI of this file system.
+     */
     private final URI internalBaseURI;
+
+    /**
+     * Internal <code>HttpClient</code> instance of this file system.
+     */
     private final HttpClient httpClient;
+
+    /**
+     * Internal <code>HttpClientContext</code> instance of this file system.
+     */
     private final HttpClientContext httpClientContext;
 
+    /**
+     * Construct <code>Http4FileSystem<code>.
+     * @param rootName root base name
+     * @param fileSystemOptions file system options
+     * @param httpClient <code>HttpClient</code> instance
+     * @param httpClientContext <code>HttpClientContext</code> instance
+     */
     protected Http4FileSystem(FileName rootName, FileSystemOptions fileSystemOptions, HttpClient httpClient,
             HttpClientContext httpClientContext) {
         super(rootName, null, fileSystemOptions);
@@ -79,14 +97,26 @@ public class Http4FileSystem extends AbstractFileSystem {
         }
     }
 
+    /**
+     * Return the internal <code>HttpClient</code> instance.
+     * @return the internal <code>HttpClient</code> instance
+     */
     protected HttpClient getHttpClient() {
         return httpClient;
     }
 
+    /**
+     * Return the internal <code>HttpClientContext</code> instance.
+     * @return the internal <code>HttpClientContext</code> instance
+     */
     protected HttpClientContext getHttpClientContext() {
         return httpClientContext;
     }
 
+    /**
+     * Return the internal base <code>URI</code> instance.
+     * @return the internal base <code>URI</code> instance
+     */
     protected URI getInternalBaseURI() {
         return internalBaseURI;
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -31,7 +31,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 /**
- * An HTTP4 file system.
+ * HTTP4 file system.
  */
 public class Http4FileSystem extends AbstractFileSystem {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileSystem;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/**
+ * An HTTP4 file system.
+ */
+public class Http4FileSystem extends AbstractFileSystem {
+
+    private final URI baseURI;
+    private final HttpClient httpClient;
+    private final HttpClientContext httpClientContext;
+
+    protected Http4FileSystem(FileName rootName, FileSystemOptions fileSystemOptions, HttpClient httpClient,
+            HttpClientContext httpClientContext) {
+        super(rootName, null, fileSystemOptions);
+
+        final String rootURI = getRootURI();
+        final int offset = rootURI.indexOf(':');
+        final String scheme = rootURI.substring(0, offset);
+
+        if ("http4s".equals(scheme)) {
+            this.baseURI = URI.create("https" + rootURI.substring(offset));
+        } else {
+            this.baseURI = URI.create("http" + rootURI.substring(offset));
+        }
+
+        this.httpClient = httpClient;
+        this.httpClientContext = httpClientContext;
+    }
+
+    @Override
+    protected FileObject createFile(AbstractFileName name) throws Exception {
+        return new Http4FileObject<>(name, this);
+    }
+
+    @Override
+    protected void addCapabilities(Collection<Capability> caps) {
+        caps.addAll(Http4FileProvider.capabilities);
+    }
+
+    @Override
+    protected void doCloseCommunicationLink() {
+        if (httpClient instanceof CloseableHttpClient) {
+            try {
+                ((CloseableHttpClient) httpClient).close();
+            } catch (IOException e) {
+                throw new RuntimeException("Error closing HttpClient", e);
+            }
+        }
+    }
+
+    protected HttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    protected HttpClientContext getHttpClientContext() {
+        return httpClientContext;
+    }
+
+    protected URI getBaseURI() {
+        return baseURI;
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -51,11 +51,11 @@ public class Http4FileSystem extends AbstractFileSystem {
     private final HttpClientContext httpClientContext;
 
     /**
-     * Construct <code>Http4FileSystem<code>.
+     * Construct <code>Http4FileSystem</code>.
      * @param rootName root base name
      * @param fileSystemOptions file system options
-     * @param httpClient <code>HttpClient</code> instance
-     * @param httpClientContext <code>HttpClientContext</code> instance
+     * @param httpClient {@link HttpClient} instance
+     * @param httpClientContext {@link HttpClientContext} instance
      */
     protected Http4FileSystem(FileName rootName, FileSystemOptions fileSystemOptions, HttpClient httpClient,
             HttpClientContext httpClientContext) {
@@ -98,16 +98,16 @@ public class Http4FileSystem extends AbstractFileSystem {
     }
 
     /**
-     * Return the internal <code>HttpClient</code> instance.
-     * @return the internal <code>HttpClient</code> instance
+     * Return the internal {@link HttpClient} instance.
+     * @return the internal {@link HttpClient} instance
      */
     protected HttpClient getHttpClient() {
         return httpClient;
     }
 
     /**
-     * Return the internal <code>HttpClientContext</code> instance.
-     * @return the internal <code>HttpClientContext</code> instance
+     * Return the internal {@link HttpClientContext} instance.
+     * @return the internal {@link HttpClientContext} instance
      */
     protected HttpClientContext getHttpClientContext() {
         return httpClientContext;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.UserAuthenticator;
+import org.apache.http.cookie.Cookie;
+
+/**
+ * Configuration options for HTTP.
+ */
+public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
+
+    protected static final String KEY_FOLLOW_REDIRECT = "followRedirect";
+
+    protected static final String KEY_USER_AGENT = "userAgent";
+
+    private static final Http4FileSystemConfigBuilder BUILDER = new Http4FileSystemConfigBuilder();
+
+    private static final String MAX_TOTAL_CONNECTIONS = "http.connection-manager.max-total";
+
+    private static final String MAX_ROUTE_CONNECTIONS = "http.connection-manager.max-per-route";
+
+    private static final String CONNECTION_TIMEOUT = "http.connection.timeout";
+
+    public static final String SO_TIMEOUT = "http.socket.timeout";
+
+    private static final int DEFAULT_MAX_ROUTE_CONNECTIONS = 5;
+
+    private static final int DEFAULT_MAX_CONNECTIONS = 50;
+
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 0;
+
+    private static final int DEFAULT_SO_TIMEOUT = 0;
+
+    private static final boolean DEFAULT_FOLLOW_REDIRECT = true;
+
+    private static final String DEFAULT_USER_AGENT = "Apache-Commons-VFS";
+
+    private static final String KEY_PREEMPTIVE_AUTHENTICATION = "preemptiveAuth";
+
+    /**
+     * Creates new config builder.
+     *
+     * @param prefix String for properties of this file system.
+     * @since 2.0
+     */
+    protected Http4FileSystemConfigBuilder(final String prefix) {
+        super(prefix);
+    }
+
+    private Http4FileSystemConfigBuilder() {
+        super("http4.");
+    }
+
+    /**
+     * Gets the singleton builder.
+     *
+     * @return the singleton builder.
+     */
+    public static Http4FileSystemConfigBuilder getInstance() {
+        return BUILDER;
+    }
+
+    /**
+     * Sets the charset used for url encoding.<br>
+     *
+     * @param opts The FileSystem options.
+     * @param chaset the chaset
+     */
+    public void setUrlCharset(final FileSystemOptions opts, final String chaset) {
+        setParam(opts, "urlCharset", chaset);
+    }
+
+    /**
+     * Sets the charset used for url encoding.<br>
+     *
+     * @param opts The FileSystem options.
+     * @return the chaset
+     */
+    public String getUrlCharset(final FileSystemOptions opts) {
+        return getString(opts, "urlCharset");
+    }
+
+    /**
+     * Sets the proxy to use for http connection.<br>
+     * You have to set the ProxyPort too if you would like to have the proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @param proxyHost the host
+     * @see #setProxyPort
+     */
+    public void setProxyHost(final FileSystemOptions opts, final String proxyHost) {
+        setParam(opts, "proxyHost", proxyHost);
+    }
+
+    /**
+     * Sets the proxy-port to use for http connection. You have to set the ProxyHost too if you would like to have the
+     * proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @param proxyPort the port
+     * @see #setProxyHost
+     */
+    public void setProxyPort(final FileSystemOptions opts, final int proxyPort) {
+        setParam(opts, "proxyPort", Integer.valueOf(proxyPort));
+    }
+
+    /**
+     * Gets the proxy to use for http connection. You have to set the ProxyPort too if you would like to have the proxy
+     * really used.
+     *
+     * @param opts The FileSystem options.
+     * @return proxyHost
+     * @see #setProxyPort
+     */
+    public String getProxyHost(final FileSystemOptions opts) {
+        return getString(opts, "proxyHost");
+    }
+
+    /**
+     * Gets the proxy-port to use for http the connection. You have to set the ProxyHost too if you would like to have
+     * the proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @return proxyPort: the port number or 0 if it is not set
+     * @see #setProxyHost
+     */
+    public int getProxyPort(final FileSystemOptions opts) {
+        return getInteger(opts, "proxyPort", 0);
+    }
+
+    /**
+     * Sets the proxy authenticator where the system should get the credentials from.
+     *
+     * @param opts The FileSystem options.
+     * @param authenticator The UserAuthenticator.
+     */
+    public void setProxyAuthenticator(final FileSystemOptions opts, final UserAuthenticator authenticator) {
+        setParam(opts, "proxyAuthenticator", authenticator);
+    }
+
+    /**
+     * Gets the proxy authenticator where the system should get the credentials from.
+     *
+     * @param opts The FileSystem options.
+     * @return The UserAuthenticator.
+     */
+    public UserAuthenticator getProxyAuthenticator(final FileSystemOptions opts) {
+        return (UserAuthenticator) getParam(opts, "proxyAuthenticator");
+    }
+
+    /**
+     * The cookies to add to the request.
+     *
+     * @param opts The FileSystem options.
+     * @param cookies An array of Cookies.
+     */
+    public void setCookies(final FileSystemOptions opts, final Cookie[] cookies) {
+        setParam(opts, "cookies", cookies);
+    }
+
+    /**
+     * Sets whether to follow redirects for the connection.
+     *
+     * @param opts The FileSystem options.
+     * @param redirect {@code true} to follow redirects, {@code false} not to.
+     * @see #setFollowRedirect
+     * @since 2.1
+     */
+    public void setFollowRedirect(final FileSystemOptions opts, final boolean redirect) {
+        setParam(opts, KEY_FOLLOW_REDIRECT, redirect);
+    }
+
+    /**
+     * Gets the cookies to add to the request.
+     *
+     * @param opts The FileSystem options.
+     * @return the Cookie array.
+     */
+    public Cookie[] getCookies(final FileSystemOptions opts) {
+        return (Cookie[]) getParam(opts, "cookies");
+    }
+
+    /**
+     * Gets whether to follow redirects for the connection.
+     *
+     * @param opts The FileSystem options.
+     * @return {@code true} to follow redirects, {@code false} not to.
+     * @see #setFollowRedirect
+     * @since 2.1
+     */
+    public boolean getFollowRedirect(final FileSystemOptions opts) {
+        return getBoolean(opts, KEY_FOLLOW_REDIRECT, DEFAULT_FOLLOW_REDIRECT);
+    }
+
+    /**
+     * Sets the maximum number of connections allowed.
+     *
+     * @param opts The FileSystem options.
+     * @param maxTotalConnections The maximum number of connections.
+     * @since 2.0
+     */
+    public void setMaxTotalConnections(final FileSystemOptions opts, final int maxTotalConnections) {
+        setParam(opts, MAX_TOTAL_CONNECTIONS, Integer.valueOf(maxTotalConnections));
+    }
+
+    /**
+     * Gets the maximum number of connections allowed.
+     *
+     * @param opts The FileSystemOptions.
+     * @return The maximum number of connections allowed.
+     * @since 2.0
+     */
+    public int getMaxTotalConnections(final FileSystemOptions opts) {
+        return getInteger(opts, MAX_TOTAL_CONNECTIONS, DEFAULT_MAX_CONNECTIONS);
+    }
+
+    /**
+     * Sets the maximum number of connections allowed to any route.
+     *
+     * @param opts The FileSystem options.
+     * @param maxRouteConnections The maximum number of connections to a route.
+     * @since 2.0
+     */
+    public void setMaxConnectionsPerRoute(final FileSystemOptions opts, final int maxRouteConnections) {
+        setParam(opts, MAX_ROUTE_CONNECTIONS, Integer.valueOf(maxRouteConnections));
+    }
+
+    /**
+     * Gets the maximum number of connections allowed per route.
+     *
+     * @param opts The FileSystemOptions.
+     * @return The maximum number of connections allowed per route.
+     * @since 2.0
+     */
+    public int getMaxConnectionsPerRoute(final FileSystemOptions opts) {
+        return getInteger(opts, MAX_ROUTE_CONNECTIONS, DEFAULT_MAX_ROUTE_CONNECTIONS);
+    }
+
+    /**
+     * Determines if the FileSystemOptions indicate that preemptive authentication is requested.
+     *
+     * @param opts The FileSystemOptions.
+     * @return true if preemptiveAuth is requested.
+     * @since 2.0
+     */
+    public boolean isPreemptiveAuth(final FileSystemOptions opts) {
+        return getBoolean(opts, KEY_PREEMPTIVE_AUTHENTICATION, Boolean.FALSE).booleanValue();
+    }
+
+    /**
+     * Sets the given value for preemptive HTTP authentication (using BASIC) on the given FileSystemOptions object.
+     * Defaults to false if not set. It may be appropriate to set to true in cases when the resulting chattiness of the
+     * conversation outweighs any architectural desire to use a stronger authentication scheme than basic/preemptive.
+     *
+     * @param opts The FileSystemOptions.
+     * @param preemptiveAuth the desired setting; true=enabled and false=disabled.
+     */
+    public void setPreemptiveAuth(final FileSystemOptions opts, final boolean preemptiveAuth) {
+        setParam(opts, KEY_PREEMPTIVE_AUTHENTICATION, Boolean.valueOf(preemptiveAuth));
+    }
+
+    /**
+     * The connection timeout.
+     *
+     * @param opts The FileSystem options.
+     * @param connectionTimeout The connection timeout.
+     * @since 2.1
+     */
+    public void setConnectionTimeout(final FileSystemOptions opts, final int connectionTimeout) {
+        setParam(opts, CONNECTION_TIMEOUT, Integer.valueOf(connectionTimeout));
+    }
+
+    /**
+     * Gets the connection timeout.
+     *
+     * @param opts The FileSystem options.
+     * @return The connection timeout.
+     * @since 2.1
+     */
+    public int getConnectionTimeout(final FileSystemOptions opts) {
+        return getInteger(opts, CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+    }
+
+    /**
+     * The socket timeout.
+     *
+     * @param opts The FileSystem options.
+     * @param soTimeout socket timeout.
+     * @since 2.1
+     */
+    public void setSoTimeout(final FileSystemOptions opts, final int soTimeout) {
+        setParam(opts, SO_TIMEOUT, Integer.valueOf(soTimeout));
+    }
+
+    /**
+     * Gets the socket timeout.
+     *
+     * @param opts The FileSystemOptions.
+     * @return The socket timeout.
+     * @since 2.1
+     */
+    public int getSoTimeout(final FileSystemOptions opts) {
+        return getInteger(opts, SO_TIMEOUT, DEFAULT_SO_TIMEOUT);
+    }
+
+    /**
+     * Sets the user agent to attach to the outgoing http methods
+     *
+     * @param opts the file system options to modify
+     * @param userAgent User Agent String
+     */
+    public void setUserAgent(final FileSystemOptions opts, final String userAgent) {
+        setParam(opts, "userAgent", userAgent);
+    }
+
+    /**
+     * Gets the user agent string
+     *
+     * @param opts the file system options to modify
+     * @return User provided User-Agent string, otherwise default of: Commons-VFS
+     */
+    public String getUserAgent(final FileSystemOptions opts) {
+        final String userAgent = (String) getParam(opts, KEY_USER_AGENT);
+        return userAgent != null ? userAgent : DEFAULT_USER_AGENT;
+    }
+
+    @Override
+    protected Class<? extends FileSystem> getConfigClass() {
+        return Http4FileSystem.class;
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -51,8 +51,7 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final int DEFAULT_SO_TIMEOUT = 0;
 
-    // TODO: Ignore Keep Alive like v3, but should we set the default to true like Http Client v4??
-    private static final boolean DEFAULT_KEEP_ALIVE = false;
+    private static final boolean DEFAULT_KEEP_ALIVE = true;
 
     private static final boolean DEFAULT_FOLLOW_REDIRECT = true;
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -23,7 +23,7 @@ import org.apache.commons.vfs2.UserAuthenticator;
 import org.apache.http.cookie.Cookie;
 
 /**
- * Configuration options for HTTP.
+ * Configuration options builder utility for HTTP4 provider.
  */
 public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -39,9 +39,13 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final String KEEP_ALIVE = "http.keepAlive";
 
+    private static final String HOSTNAME_VERIFICATION_ENABLED = "http.hostname-verification.enabled";
+
     private static final String KEY_FOLLOW_REDIRECT = "followRedirect";
 
     private static final String KEY_USER_AGENT = "userAgent";
+
+    private static final String KEY_PREEMPTIVE_AUTHENTICATION = "preemptiveAuth";
 
     private static final int DEFAULT_MAX_ROUTE_CONNECTIONS = 5;
 
@@ -57,7 +61,7 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final String DEFAULT_USER_AGENT = "Apache-Commons-VFS";
 
-    private static final String KEY_PREEMPTIVE_AUTHENTICATION = "preemptiveAuth";
+    private static final boolean DEFAULT_HOSTNAME_VERIFICATION_ENABLED = true;
 
     /**
      * Creates new config builder.
@@ -351,6 +355,26 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     public String getUserAgent(final FileSystemOptions opts) {
         final String userAgent = (String) getParam(opts, KEY_USER_AGENT);
         return userAgent != null ? userAgent : DEFAULT_USER_AGENT;
+    }
+
+    /**
+     * Sets if the hostname should be verified in SSL context.
+     *
+     * @param opts The FileSystemOptions.
+     * @param hostnameVerificationEnabled whether hostname should be verified
+     */
+    public void setHostnameVerificationEnabled(final FileSystemOptions opts, boolean hostnameVerificationEnabled) {
+        setParam(opts, HOSTNAME_VERIFICATION_ENABLED, Boolean.valueOf(hostnameVerificationEnabled));
+    }
+
+    /**
+     * Determines if the hostname should be verified in SSL context.
+     *
+     * @param opts The FileSystemOptions.
+     * @return true if if the FileSystemOptions indicate that HTTP Keep-Alive is respected.
+     */
+    public boolean isHostnameVerificationEnabled(final FileSystemOptions opts) {
+        return getBoolean(opts, HOSTNAME_VERIFICATION_ENABLED, DEFAULT_HOSTNAME_VERIFICATION_ENABLED);
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -23,52 +23,142 @@ import org.apache.commons.vfs2.UserAuthenticator;
 import org.apache.http.cookie.Cookie;
 
 /**
- * Configuration options builder utility for HTTP4 provider.
+ * Configuration options builder utility for http4 provider.
  */
 public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final Http4FileSystemConfigBuilder BUILDER = new Http4FileSystemConfigBuilder();
 
+    /** 
+     * Defines the maximum number of connections allowed overall. This value only applies
+     * to the number of connections from a particular instance of HTTP connection manager.
+     * <p>
+     * This parameter expects a value of type {@link Integer}.
+     * </p>
+     */
     private static final String MAX_TOTAL_CONNECTIONS = "http.connection-manager.max-total";
 
-    private static final String MAX_ROUTE_CONNECTIONS = "http.connection-manager.max-per-route";
+    /** 
+     * Defines the maximum number of connections allowed per host configuration. 
+     * These values only apply to the number of connections from a particular instance 
+     * of HTTP connection manager.
+     */
+    private static final String MAX_HOST_CONNECTIONS = "http.connection-manager.max-per-host";
 
+    /** 
+     * Defines the connection timeout of an HTTP request.
+     * <p>
+     * This parameter expects a value of type {@link Integer}.
+     * </p>
+     */
     private static final String CONNECTION_TIMEOUT = "http.connection.timeout";
 
+    /** 
+     * Defines the socket timeout of an HTTP request.
+     * <p>
+     * This parameter expects a value of type {@link Integer}.
+     * </p>
+     */
     private static final String SO_TIMEOUT = "http.socket.timeout";
 
+    /** 
+     * Defines whether Keep-Alive option is used or not.
+     * <p>
+     * This parameter expects a value of type {@link Boolean}.
+     * </p>
+     */
     private static final String KEEP_ALIVE = "http.keepAlive";
 
+    /** 
+     * Defines the keystore file path for SSL connections.
+     * <p>
+     * This parameter expects a value of type {@link String}.
+     * </p>
+     */
     private static final String KEYSTORE_FILE = "http.keystoreFile";
 
+    /** 
+     * Defines the keystore pass phrase for SSL connections.
+     * <p>
+     * This parameter expects a value of type {@link String}.
+     * </p>
+     */
     private static final String KEYSTORE_PASS = "http.keystorePass";
 
+    /** 
+     * Defines whether the host name should be verified or not in SSL connections.
+     * <p>
+     * This parameter expects a value of type {@link Boolean}.
+     * </p>
+     */
     private static final String HOSTNAME_VERIFICATION_ENABLED = "http.hostname-verification.enabled";
 
+    /** 
+     * Defines whether the HttpClient should follow redirections from the responses.
+     * <p>
+     * This parameter expects a value of type {@link Boolean}.
+     * </p>
+     */
     private static final String KEY_FOLLOW_REDIRECT = "followRedirect";
 
+    /** 
+     * Defines the User-Agent request header string of the underlying HttpClient.
+     * <p>
+     * This parameter expects a value of type {@link String}.
+     * </p>
+     */
     private static final String KEY_USER_AGENT = "userAgent";
 
+    /** 
+     * Defines whether the preemptive authentication should be enabled or not.
+     * <p>
+     * This parameter expects a value of type {@link Boolean}.
+     * </p>
+     */
     private static final String KEY_PREEMPTIVE_AUTHENTICATION = "preemptiveAuth";
 
-    private static final int DEFAULT_MAX_ROUTE_CONNECTIONS = 5;
-
+    /**
+     * The default value for {@link #MAX_TOTAL_CONNECTIONS} configuration.
+     */
     private static final int DEFAULT_MAX_CONNECTIONS = 50;
 
+    /**
+     * The default value for {@link #MAX_HOST_CONNECTIONS} configuration.
+     */
+    private static final int DEFAULT_MAX_HOST_CONNECTIONS = 5;
+
+    /**
+     * The default value for {@link #CONNECTION_TIMEOUT} configuration.
+     */
     private static final int DEFAULT_CONNECTION_TIMEOUT = 0;
 
+    /**
+     * The default value for {@link #SO_TIMEOUT} configuration.
+     */
     private static final int DEFAULT_SO_TIMEOUT = 0;
 
+    /**
+     * The default value for {@link #KEEP_ALIVE} configuration.
+     */
     private static final boolean DEFAULT_KEEP_ALIVE = true;
 
+    /**
+     * The default value for {@link #KEY_FOLLOW_REDIRECT} configuration.
+     */
     private static final boolean DEFAULT_FOLLOW_REDIRECT = true;
 
-    private static final String DEFAULT_USER_AGENT = "Apache-Commons-VFS";
+    /**
+     * The default value for {@link #KEY_USER_AGENT} configuration.
+     */
+    private static final String DEFAULT_USER_AGENT = "Jakarta-Commons-VFS";
 
+    /**
+     * The default value for {@link #HOSTNAME_VERIFICATION_ENABLED} configuration.
+     */
     private static final boolean DEFAULT_HOSTNAME_VERIFICATION_ENABLED = true;
 
     /**
-     * Creates new config builder.
+     * Construct an <code>Http4FileSystemConfigBuilder</code>.
      *
      * @param prefix String for properties of this file system.
      */
@@ -77,7 +167,7 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     private Http4FileSystemConfigBuilder() {
-        super("http4.");
+        super("http.");
     }
 
     /**
@@ -240,23 +330,23 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     /**
-     * Sets the maximum number of connections allowed to any route.
+     * Sets the maximum number of connections allowed to any host.
      *
      * @param opts The FileSystem options.
-     * @param maxRouteConnections The maximum number of connections to a route.
+     * @param maxHostConnections The maximum number of connections to a host.
      */
-    public void setMaxConnectionsPerRoute(final FileSystemOptions opts, final int maxRouteConnections) {
-        setParam(opts, MAX_ROUTE_CONNECTIONS, Integer.valueOf(maxRouteConnections));
+    public void setMaxConnectionsPerHost(final FileSystemOptions opts, final int maxHostConnections) {
+        setParam(opts, MAX_HOST_CONNECTIONS, Integer.valueOf(maxHostConnections));
     }
 
     /**
-     * Gets the maximum number of connections allowed per route.
+     * Gets the maximum number of connections allowed per host.
      *
      * @param opts The FileSystemOptions.
-     * @return The maximum number of connections allowed per route.
+     * @return The maximum number of connections allowed per host.
      */
-    public int getMaxConnectionsPerRoute(final FileSystemOptions opts) {
-        return getInteger(opts, MAX_ROUTE_CONNECTIONS, DEFAULT_MAX_ROUTE_CONNECTIONS);
+    public int getMaxConnectionsPerHost(final FileSystemOptions opts) {
+        return getInteger(opts, MAX_HOST_CONNECTIONS, DEFAULT_MAX_HOST_CONNECTIONS);
     }
 
     /**
@@ -361,19 +451,39 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
         return userAgent != null ? userAgent : DEFAULT_USER_AGENT;
     }
 
+    /**
+     * Set keystore file path for SSL connections.
+     * @param opts the file system options to modify
+     * @param keyStoreFile keystore file path
+     */
     public void setKeyStoreFile(final FileSystemOptions opts, String keyStoreFile) {
         setParam(opts, KEYSTORE_FILE, keyStoreFile);
     }
 
+    /**
+     * Return keystore file path to be used in SSL connections.
+     * @param opts the file system options to modify
+     * @return keystore file path to be used in SSL connections
+     */
     public String getKeyStoreFile(final FileSystemOptions opts) {
         return (String) getParam(opts, KEYSTORE_FILE);
     }
 
+    /**
+     * Set keystore pass phrase for SSL connecdtions.
+     * @param opts the file system options to modify
+     * @param keyStorePass keystore pass phrase for SSL connecdtions
+     */
     public void setKeyStorePass(final FileSystemOptions opts, String keyStorePass) {
         setParam(opts, KEYSTORE_PASS, keyStorePass);
     }
 
-    public String getKeyStorePass(final FileSystemOptions opts) {
+    /**
+     * Return keystore pass phrase for SSL connections.
+     * @param opts the file system options to modify
+     * @return keystore pass phrase for SSL connections
+     */
+    String getKeyStorePass(final FileSystemOptions opts) {
         return (String) getParam(opts, KEYSTORE_PASS);
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -39,6 +39,10 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final String KEEP_ALIVE = "http.keepAlive";
 
+    private static final String KEYSTORE_FILE = "http.keystoreFile";
+
+    private static final String KEYSTORE_PASS = "http.keystorePass";
+
     private static final String HOSTNAME_VERIFICATION_ENABLED = "http.hostname-verification.enabled";
 
     private static final String KEY_FOLLOW_REDIRECT = "followRedirect";
@@ -355,6 +359,22 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     public String getUserAgent(final FileSystemOptions opts) {
         final String userAgent = (String) getParam(opts, KEY_USER_AGENT);
         return userAgent != null ? userAgent : DEFAULT_USER_AGENT;
+    }
+
+    public void setKeyStoreFile(final FileSystemOptions opts, String keyStoreFile) {
+        setParam(opts, KEYSTORE_FILE, keyStoreFile);
+    }
+
+    public String getKeyStoreFile(final FileSystemOptions opts) {
+        return (String) getParam(opts, KEYSTORE_FILE);
+    }
+
+    public void setKeyStorePass(final FileSystemOptions opts, String keyStorePass) {
+        setParam(opts, KEYSTORE_PASS, keyStorePass);
+    }
+
+    public String getKeyStorePass(final FileSystemOptions opts) {
+        return (String) getParam(opts, KEYSTORE_PASS);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -415,6 +415,7 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * Sets if the FileSystemOptions indicate that HTTP Keep-Alive is respected.
      *
      * @param opts The FileSystemOptions.
+     * @param keepAlive whether the FileSystemOptions indicate that HTTP Keep-Alive is respected or not.
      */
     public void setKeepAlive(final FileSystemOptions opts, boolean keepAlive) {
         setParam(opts, KEEP_ALIVE, Boolean.valueOf(keepAlive));

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -27,10 +27,6 @@ import org.apache.http.cookie.Cookie;
  */
 public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
-    protected static final String KEY_FOLLOW_REDIRECT = "followRedirect";
-
-    protected static final String KEY_USER_AGENT = "userAgent";
-
     private static final Http4FileSystemConfigBuilder BUILDER = new Http4FileSystemConfigBuilder();
 
     private static final String MAX_TOTAL_CONNECTIONS = "http.connection-manager.max-total";
@@ -39,7 +35,13 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final String CONNECTION_TIMEOUT = "http.connection.timeout";
 
-    public static final String SO_TIMEOUT = "http.socket.timeout";
+    private static final String SO_TIMEOUT = "http.socket.timeout";
+
+    private static final String KEEP_ALIVE = "http.keepAlive";
+
+    private static final String KEY_FOLLOW_REDIRECT = "followRedirect";
+
+    private static final String KEY_USER_AGENT = "userAgent";
 
     private static final int DEFAULT_MAX_ROUTE_CONNECTIONS = 5;
 
@@ -48,6 +50,9 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final int DEFAULT_CONNECTION_TIMEOUT = 0;
 
     private static final int DEFAULT_SO_TIMEOUT = 0;
+
+    // TODO: Ignore Keep Alive like v3, but should we set the default to true like Http Client v4??
+    private static final boolean DEFAULT_KEEP_ALIVE = false;
 
     private static final boolean DEFAULT_FOLLOW_REDIRECT = true;
 
@@ -59,7 +64,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * Creates new config builder.
      *
      * @param prefix String for properties of this file system.
-     * @since 2.0
      */
     protected Http4FileSystemConfigBuilder(final String prefix) {
         super(prefix);
@@ -182,7 +186,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * @param opts The FileSystem options.
      * @param redirect {@code true} to follow redirects, {@code false} not to.
      * @see #setFollowRedirect
-     * @since 2.1
      */
     public void setFollowRedirect(final FileSystemOptions opts, final boolean redirect) {
         setParam(opts, KEY_FOLLOW_REDIRECT, redirect);
@@ -204,7 +207,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * @param opts The FileSystem options.
      * @return {@code true} to follow redirects, {@code false} not to.
      * @see #setFollowRedirect
-     * @since 2.1
      */
     public boolean getFollowRedirect(final FileSystemOptions opts) {
         return getBoolean(opts, KEY_FOLLOW_REDIRECT, DEFAULT_FOLLOW_REDIRECT);
@@ -215,7 +217,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystem options.
      * @param maxTotalConnections The maximum number of connections.
-     * @since 2.0
      */
     public void setMaxTotalConnections(final FileSystemOptions opts, final int maxTotalConnections) {
         setParam(opts, MAX_TOTAL_CONNECTIONS, Integer.valueOf(maxTotalConnections));
@@ -226,7 +227,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystemOptions.
      * @return The maximum number of connections allowed.
-     * @since 2.0
      */
     public int getMaxTotalConnections(final FileSystemOptions opts) {
         return getInteger(opts, MAX_TOTAL_CONNECTIONS, DEFAULT_MAX_CONNECTIONS);
@@ -237,7 +237,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystem options.
      * @param maxRouteConnections The maximum number of connections to a route.
-     * @since 2.0
      */
     public void setMaxConnectionsPerRoute(final FileSystemOptions opts, final int maxRouteConnections) {
         setParam(opts, MAX_ROUTE_CONNECTIONS, Integer.valueOf(maxRouteConnections));
@@ -248,7 +247,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystemOptions.
      * @return The maximum number of connections allowed per route.
-     * @since 2.0
      */
     public int getMaxConnectionsPerRoute(final FileSystemOptions opts) {
         return getInteger(opts, MAX_ROUTE_CONNECTIONS, DEFAULT_MAX_ROUTE_CONNECTIONS);
@@ -259,7 +257,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystemOptions.
      * @return true if preemptiveAuth is requested.
-     * @since 2.0
      */
     public boolean isPreemptiveAuth(final FileSystemOptions opts) {
         return getBoolean(opts, KEY_PREEMPTIVE_AUTHENTICATION, Boolean.FALSE).booleanValue();
@@ -282,7 +279,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystem options.
      * @param connectionTimeout The connection timeout.
-     * @since 2.1
      */
     public void setConnectionTimeout(final FileSystemOptions opts, final int connectionTimeout) {
         setParam(opts, CONNECTION_TIMEOUT, Integer.valueOf(connectionTimeout));
@@ -293,7 +289,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystem options.
      * @return The connection timeout.
-     * @since 2.1
      */
     public int getConnectionTimeout(final FileSystemOptions opts) {
         return getInteger(opts, CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
@@ -304,7 +299,6 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystem options.
      * @param soTimeout socket timeout.
-     * @since 2.1
      */
     public void setSoTimeout(final FileSystemOptions opts, final int soTimeout) {
         setParam(opts, SO_TIMEOUT, Integer.valueOf(soTimeout));
@@ -315,10 +309,28 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      *
      * @param opts The FileSystemOptions.
      * @return The socket timeout.
-     * @since 2.1
      */
     public int getSoTimeout(final FileSystemOptions opts) {
         return getInteger(opts, SO_TIMEOUT, DEFAULT_SO_TIMEOUT);
+    }
+
+    /**
+     * Sets if the FileSystemOptions indicate that HTTP Keep-Alive is respected.
+     *
+     * @param opts The FileSystemOptions.
+     */
+    public void setKeepAlive(final FileSystemOptions opts, boolean keepAlive) {
+        setParam(opts, KEEP_ALIVE, Boolean.valueOf(keepAlive));
+    }
+
+    /**
+     * Determines if the FileSystemOptions indicate that HTTP Keep-Alive is respected.
+     *
+     * @param opts The FileSystemOptions.
+     * @return true if if the FileSystemOptions indicate that HTTP Keep-Alive is respected.
+     */
+    public boolean isKeepAlive(final FileSystemOptions opts) {
+        return getBoolean(opts, KEEP_ALIVE, DEFAULT_KEEP_ALIVE);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
@@ -29,7 +29,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 /**
- * RandomAccess content using HTTP.
+ * RandomAccess content using HTTP4.
  */
 class Http4RandomAccessContent<FS extends Http4FileSystem> extends AbstractRandomAccessStreamContent {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.io.DataInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.AbstractRandomAccessStreamContent;
+import org.apache.commons.vfs2.util.MonitorInputStream;
+import org.apache.commons.vfs2.util.RandomAccessMode;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+
+/**
+ * RandomAccess content using HTTP.
+ */
+class Http4RandomAccessContent<FS extends Http4FileSystem> extends AbstractRandomAccessStreamContent {
+
+    protected long filePointer = 0;
+
+    private final Http4FileObject<FS> fileObject;
+
+    private DataInputStream dis = null;
+    private MonitorInputStream mis = null;
+
+    Http4RandomAccessContent(final Http4FileObject<FS> fileObject, final RandomAccessMode mode) {
+        super(mode);
+        this.fileObject = fileObject;
+    }
+
+    @Override
+    public long getFilePointer() throws IOException {
+        return filePointer;
+    }
+
+    @Override
+    public void seek(final long pos) throws IOException {
+        if (pos == filePointer) {
+            // no change
+            return;
+        }
+
+        if (pos < 0) {
+            throw new FileSystemException("vfs.provider/random-access-invalid-position.error", Long.valueOf(pos));
+        }
+
+        if (dis != null) {
+            close();
+        }
+
+        filePointer = pos;
+    }
+
+    @Override
+    protected DataInputStream getDataInputStream() throws IOException {
+        if (dis != null) {
+            return dis;
+        }
+
+        final HttpGet httpGet = new HttpGet(fileObject.getURI());
+        httpGet.setHeader("Range", "bytes=" + filePointer + "-");
+        final HttpResponse httpResponse = fileObject.executeHttpUriRequest(httpGet);
+        final int status = httpResponse.getStatusLine().getStatusCode();
+
+        if (status != HttpURLConnection.HTTP_PARTIAL && status != HttpURLConnection.HTTP_OK) {
+            throw new FileSystemException("vfs.provider.http/get-range.error", fileObject.getName(),
+                    Long.valueOf(filePointer), Integer.valueOf(status));
+        }
+
+        mis = new MonitoredHttpResponseContentInputStream(httpResponse);
+
+        // If the range request was ignored
+        if (status == HttpURLConnection.HTTP_OK) {
+            final long skipped = mis.skip(filePointer);
+            if (skipped != filePointer) {
+                throw new FileSystemException("vfs.provider.http/get-range.error", fileObject.getName(),
+                        Long.valueOf(filePointer), Integer.valueOf(status));
+            }
+        }
+
+        dis = new DataInputStream(new FilterInputStream(mis) {
+            @Override
+            public int read() throws IOException {
+                final int ret = super.read();
+                if (ret > -1) {
+                    filePointer++;
+                }
+                return ret;
+            }
+
+            @Override
+            public int read(final byte[] b) throws IOException {
+                final int ret = super.read(b);
+                if (ret > -1) {
+                    filePointer += ret;
+                }
+                return ret;
+            }
+
+            @Override
+            public int read(final byte[] b, final int off, final int len) throws IOException {
+                final int ret = super.read(b, off, len);
+                if (ret > -1) {
+                    filePointer += ret;
+                }
+                return ret;
+            }
+        });
+
+        return dis;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (dis != null) {
+            dis.close();
+            dis = null;
+            mis = null;
+        }
+    }
+
+    @Override
+    public long length() throws IOException {
+        return fileObject.getContent().getSize();
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
@@ -29,7 +29,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 /**
- * RandomAccess content using HTTP4.
+ * RandomAccess content using <code>Http4FileObject</code>.
  */
 class Http4RandomAccessContent<FS extends Http4FileSystem> extends AbstractRandomAccessStreamContent {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4RandomAccessContent.java
@@ -74,7 +74,7 @@ class Http4RandomAccessContent<FS extends Http4FileSystem> extends AbstractRando
             return dis;
         }
 
-        final HttpGet httpGet = new HttpGet(fileObject.getURI());
+        final HttpGet httpGet = new HttpGet(fileObject.getInternalURI());
         httpGet.setHeader("Range", "bytes=" + filePointer + "-");
         final HttpResponse httpResponse = fileObject.executeHttpUriRequest(httpGet);
         final int status = httpResponse.getStatusLine().getStatusCode();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.io.IOException;
+
+import org.apache.commons.vfs2.util.MonitorInputStream;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+class MonitoredHttpResponseContentInputStream extends MonitorInputStream {
+
+    private final HttpResponse httpResponse;
+
+    public MonitoredHttpResponseContentInputStream(final HttpResponse httpResponse) throws IOException {
+        super(httpResponse.getEntity().getContent());
+        this.httpResponse = httpResponse;
+    }
+
+    @Override
+    protected void onClose() throws IOException {
+        if (httpResponse instanceof CloseableHttpResponse) {
+            ((CloseableHttpResponse) httpResponse).close();
+        }
+    }
+
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
@@ -22,6 +22,9 @@ import org.apache.commons.vfs2.util.MonitorInputStream;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
+/**
+ * An InputStream that cleans up the <code>org.apache.http.client.methods.CloseableHttpResponse</code> on close.
+ */
 class MonitoredHttpResponseContentInputStream extends MonitorInputStream {
 
     private final HttpResponse httpResponse;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/package.html
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/package.html
@@ -1,0 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<body>
+<p>The HTTP4 File Provider</p>
+</body>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileNameParser.java
@@ -20,7 +20,7 @@ import org.apache.commons.vfs2.provider.FileNameParser;
 import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
 
 /**
- * Implementation for http4. set default port to 443.
+ * <code>FileNameParser</code> implementation for http4s provider, setting default port to 443.
  */
 public class Http4sFileNameParser extends GenericURLFileNameParser {
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileNameParser.java
@@ -14,21 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.vfs2.provider.http4;
+package org.apache.commons.vfs2.provider.http4s;
 
 import org.apache.commons.vfs2.provider.FileNameParser;
 import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
 
 /**
- * Implementation for http4. set default port to 80.
+ * Implementation for http4. set default port to 443.
  */
-public class Http4FileNameParser extends GenericURLFileNameParser {
+public class Http4sFileNameParser extends GenericURLFileNameParser {
 
-    private static final int DEFAULT_PORT = 80;
+    private static final int DEFAULT_PORT = 443;
 
-    private static final Http4FileNameParser INSTANCE = new Http4FileNameParser();
+    private static final Http4sFileNameParser INSTANCE = new Http4sFileNameParser();
 
-    public Http4FileNameParser() {
+    public Http4sFileNameParser() {
         super(DEFAULT_PORT);
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileProvider.java
@@ -19,10 +19,13 @@ package org.apache.commons.vfs2.provider.http4s;
 import org.apache.commons.vfs2.provider.http4.Http4FileProvider;
 
 /**
- * HTTP4S provider that uses HttpComponents HttpClient.
+ * http4s provider that uses HttpComponents HttpClient.
  */
 public class Http4sFileProvider extends Http4FileProvider {
 
+    /**
+     * Construct a <code>Http4sFileProvider</code>.
+     */
     public Http4sFileProvider() {
         super();
         setFileNameParser(Http4sFileNameParser.getInstance());

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/Http4sFileProvider.java
@@ -14,25 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.vfs2.provider.http4;
+package org.apache.commons.vfs2.provider.http4s;
 
-import org.apache.commons.vfs2.provider.FileNameParser;
-import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
+import org.apache.commons.vfs2.provider.http4.Http4FileProvider;
 
 /**
- * Implementation for http4. set default port to 80.
+ * HTTP4S provider that uses HttpComponents HttpClient.
  */
-public class Http4FileNameParser extends GenericURLFileNameParser {
+public class Http4sFileProvider extends Http4FileProvider {
 
-    private static final int DEFAULT_PORT = 80;
-
-    private static final Http4FileNameParser INSTANCE = new Http4FileNameParser();
-
-    public Http4FileNameParser() {
-        super(DEFAULT_PORT);
-    }
-
-    public static FileNameParser getInstance() {
-        return INSTANCE;
+    public Http4sFileProvider() {
+        super();
+        setFileNameParser(Http4sFileNameParser.getInstance());
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/package.html
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4s/package.html
@@ -1,0 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<body>
+<p>The HTTP4S File Provider</p>
+</body>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/url/UrlFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/url/UrlFileProvider.java
@@ -16,8 +16,7 @@
  */
 package org.apache.commons.vfs2.provider.url;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,31 +47,30 @@ public class UrlFileProvider extends AbstractFileProvider {
      * Locates a file object, by absolute URI.
      *
      * @param baseFile The base FileObject.
-     * @param uri The uri of the file to locate.
+     * @param fileUri The uri of the file to locate.
      * @param fileSystemOptions The FileSystemOptions
      * @return The FileObject
      * @throws FileSystemException if an error occurs.
      */
     @Override
-    public synchronized FileObject findFile(final FileObject baseFile, final String uri,
+    public synchronized FileObject findFile(final FileObject baseFile, final String fileUri,
             final FileSystemOptions fileSystemOptions) throws FileSystemException {
         try {
-            final URL url = new URL(uri);
-
-            final URL rootUrl = new URL(url, "/");
-            final String key = this.getClass().getName() + rootUrl.toString();
+            final URI uri = URI.create(fileUri);
+            final URI rootUri = uri.resolve("/");
+            final String key = this.getClass().getName() + rootUri.toString();
             FileSystem fs = findFileSystem(key, fileSystemOptions);
             if (fs == null) {
-                final String extForm = rootUrl.toExternalForm();
+                final String extForm = rootUri.toString();
                 final FileName rootName = getContext().parseURI(extForm);
                 // final FileName rootName =
                 // new BasicFileName(rootUrl, FileName.ROOT_PATH);
                 fs = new UrlFileSystem(rootName, fileSystemOptions);
                 addFileSystem(key, fs);
             }
-            return fs.resolveFile(url.getPath());
-        } catch (final MalformedURLException e) {
-            throw new FileSystemException("vfs.provider.url/badly-formed-uri.error", uri, e);
+            return fs.resolveFile(uri.getPath());
+        } catch (final Exception e) {
+            throw new FileSystemException("vfs.provider.url/badly-formed-uri.error", fileUri, e);
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIBitSets.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIBitSets.java
@@ -1,0 +1,939 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.util;
+
+import java.util.BitSet;
+
+import org.apache.commons.vfs2.provider.GenericURLFileName;
+
+/**
+ * Internal URI encoding {@link BitSet} definitions.
+ * <P>
+ * This was forked from the {@link BitSet}s in <code>org.apache.commons.httpclient.URI</code>,
+ * in order to not be dependent on HttpClient v3 API, when generating and handling {@link GenericURLFileName}s, 
+ * but it should work with any different HTTP backend provider implementations.
+ */
+class URIBitSets {
+
+    // ---------------------- Generous characters for each component validation
+
+    /**
+     * The percent "%" character always has the reserved purpose of being the
+     * escape indicator, it must be escaped as "%25" in order to be used as
+     * data within a URI.
+     */
+    protected static final BitSet percent = new BitSet(256);
+    // Static initializer for percent
+    static {
+        percent.set('%');
+    }
+
+
+    /**
+     * BitSet for digit.
+     * <p><blockquote><pre>
+     * digit    = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |
+     *            "8" | "9"
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet digit = new BitSet(256);
+    // Static initializer for digit
+    static {
+        for (int i = '0'; i <= '9'; i++) {
+            digit.set(i);
+        }
+    }
+
+
+    /**
+     * BitSet for alpha.
+     * <p><blockquote><pre>
+     * alpha         = lowalpha | upalpha
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet alpha = new BitSet(256);
+    // Static initializer for alpha
+    static {
+        for (int i = 'a'; i <= 'z'; i++) {
+            alpha.set(i);
+        }
+        for (int i = 'A'; i <= 'Z'; i++) {
+            alpha.set(i);
+        }
+    }
+
+
+    /**
+     * BitSet for alphanum (join of alpha &amp; digit).
+     * <p><blockquote><pre>
+     *  alphanum      = alpha | digit
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet alphanum = new BitSet(256);
+    // Static initializer for alphanum
+    static {
+        alphanum.or(alpha);
+        alphanum.or(digit);
+    }
+
+
+    /**
+     * BitSet for hex.
+     * <p><blockquote><pre>
+     * hex           = digit | "A" | "B" | "C" | "D" | "E" | "F" |
+     *                         "a" | "b" | "c" | "d" | "e" | "f"
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet hex = new BitSet(256);
+    // Static initializer for hex
+    static {
+        hex.or(digit);
+        for (int i = 'a'; i <= 'f'; i++) {
+            hex.set(i);
+        }
+        for (int i = 'A'; i <= 'F'; i++) {
+            hex.set(i);
+        }
+    }
+
+
+    /**
+     * BitSet for escaped.
+     * <p><blockquote><pre>
+     * escaped       = "%" hex hex
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet escaped = new BitSet(256);
+    // Static initializer for escaped
+    static {
+        escaped.or(percent);
+        escaped.or(hex);
+    }
+
+
+    /**
+     * BitSet for mark.
+     * <p><blockquote><pre>
+     * mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" |
+     *                 "(" | ")"
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet mark = new BitSet(256);
+    // Static initializer for mark
+    static {
+        mark.set('-');
+        mark.set('_');
+        mark.set('.');
+        mark.set('!');
+        mark.set('~');
+        mark.set('*');
+        mark.set('\'');
+        mark.set('(');
+        mark.set(')');
+    }
+
+
+    /**
+     * Data characters that are allowed in a URI but do not have a reserved
+     * purpose are called unreserved.
+     * <p><blockquote><pre>
+     * unreserved    = alphanum | mark
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet unreserved = new BitSet(256);
+    // Static initializer for unreserved
+    static {
+        unreserved.or(alphanum);
+        unreserved.or(mark);
+    }
+
+
+    /**
+     * BitSet for reserved.
+     * <p><blockquote><pre>
+     * reserved      = ";" | "/" | "?" | ":" | "@" | "&amp;" | "=" | "+" |
+     *                 "$" | ","
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet reserved = new BitSet(256);
+    // Static initializer for reserved
+    static {
+        reserved.set(';');
+        reserved.set('/');
+        reserved.set('?');
+        reserved.set(':');
+        reserved.set('@');
+        reserved.set('&');
+        reserved.set('=');
+        reserved.set('+');
+        reserved.set('$');
+        reserved.set(',');
+    }
+
+
+    /**
+     * BitSet for uric.
+     * <p><blockquote><pre>
+     * uric          = reserved | unreserved | escaped
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet uric = new BitSet(256);
+    // Static initializer for uric
+    static {
+        uric.or(reserved);
+        uric.or(unreserved);
+        uric.or(escaped);
+    }
+
+
+    /**
+     * BitSet for fragment (alias for uric).
+     * <p><blockquote><pre>
+     * fragment      = *uric
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet fragment = uric;
+
+
+    /**
+     * BitSet for query (alias for uric).
+     * <p><blockquote><pre>
+     * query         = *uric
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet query = uric;
+
+
+    /**
+     * BitSet for pchar.
+     * <p><blockquote><pre>
+     * pchar         = unreserved | escaped |
+     *                 ":" | "@" | "&amp;" | "=" | "+" | "$" | ","
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet pchar = new BitSet(256);
+    // Static initializer for pchar
+    static {
+        pchar.or(unreserved);
+        pchar.or(escaped);
+        pchar.set(':');
+        pchar.set('@');
+        pchar.set('&');
+        pchar.set('=');
+        pchar.set('+');
+        pchar.set('$');
+        pchar.set(',');
+    }
+
+
+    /**
+     * BitSet for param (alias for pchar).
+     * <p><blockquote><pre>
+     * param         = *pchar
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet param = pchar;
+
+
+    /**
+     * BitSet for segment.
+     * <p><blockquote><pre>
+     * segment       = *pchar *( ";" param )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet segment = new BitSet(256);
+    // Static initializer for segment
+    static {
+        segment.or(pchar);
+        segment.set(';');
+        segment.or(param);
+    }
+
+
+    /**
+     * BitSet for path segments.
+     * <p><blockquote><pre>
+     * path_segments = segment *( "/" segment )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet path_segments = new BitSet(256);
+    // Static initializer for path_segments
+    static {
+        path_segments.set('/');
+        path_segments.or(segment);
+    }
+
+
+    /**
+     * URI absolute path.
+     * <p><blockquote><pre>
+     * abs_path      = "/"  path_segments
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet abs_path = new BitSet(256);
+    // Static initializer for abs_path
+    static {
+        abs_path.set('/');
+        abs_path.or(path_segments);
+    }
+
+
+    /**
+     * URI bitset for encoding typical non-slash characters.
+     * <p><blockquote><pre>
+     * uric_no_slash = unreserved | escaped | ";" | "?" | ":" | "@" |
+     *                 "&amp;" | "=" | "+" | "$" | ","
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet uric_no_slash = new BitSet(256);
+    // Static initializer for uric_no_slash
+    static {
+        uric_no_slash.or(unreserved);
+        uric_no_slash.or(escaped);
+        uric_no_slash.set(';');
+        uric_no_slash.set('?');
+        uric_no_slash.set(';');
+        uric_no_slash.set('@');
+        uric_no_slash.set('&');
+        uric_no_slash.set('=');
+        uric_no_slash.set('+');
+        uric_no_slash.set('$');
+        uric_no_slash.set(',');
+    }
+    
+
+    /**
+     * URI bitset that combines uric_no_slash and uric.
+     * <p><blockquote><pre>
+     * opaque_part   = uric_no_slash *uric
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet opaque_part = new BitSet(256);
+    // Static initializer for opaque_part
+    static {
+        // it's generous. because first character must not include a slash
+        opaque_part.or(uric_no_slash);
+        opaque_part.or(uric);
+    }
+    
+
+    /**
+     * URI bitset that combines absolute path and opaque part.
+     * <p><blockquote><pre>
+     * path          = [ abs_path | opaque_part ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet path = new BitSet(256);
+    // Static initializer for path
+    static {
+        path.or(abs_path);
+        path.or(opaque_part);
+    }
+
+
+    /**
+     * Port, a logical alias for digit.
+     */
+    protected static final BitSet port = digit;
+
+
+    /**
+     * Bitset that combines digit and dot fo IPv$address.
+     * <p><blockquote><pre>
+     * IPv4address   = 1*digit "." 1*digit "." 1*digit "." 1*digit
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet IPv4address = new BitSet(256);
+    // Static initializer for IPv4address
+    static {
+        IPv4address.or(digit);
+        IPv4address.set('.');
+    }
+
+
+    /**
+     * RFC 2373.
+     * <p><blockquote><pre>
+     * IPv6address = hexpart [ ":" IPv4address ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet IPv6address = new BitSet(256);
+    // Static initializer for IPv6address reference
+    static {
+        IPv6address.or(hex); // hexpart
+        IPv6address.set(':');
+        IPv6address.or(IPv4address);
+    }
+
+
+    /**
+     * RFC 2732, 2373.
+     * <p><blockquote><pre>
+     * IPv6reference   = "[" IPv6address "]"
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet IPv6reference = new BitSet(256);
+    // Static initializer for IPv6reference
+    static {
+        IPv6reference.set('[');
+        IPv6reference.or(IPv6address);
+        IPv6reference.set(']');
+    }
+
+
+    /**
+     * BitSet for toplabel.
+     * <p><blockquote><pre>
+     * toplabel      = alpha | alpha *( alphanum | "-" ) alphanum
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet toplabel = new BitSet(256);
+    // Static initializer for toplabel
+    static {
+        toplabel.or(alphanum);
+        toplabel.set('-');
+    }
+
+
+    /**
+     * BitSet for domainlabel.
+     * <p><blockquote><pre>
+     * domainlabel   = alphanum | alphanum *( alphanum | "-" ) alphanum
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet domainlabel = toplabel;
+
+
+    /**
+     * BitSet for hostname.
+     * <p><blockquote><pre>
+     * hostname      = *( domainlabel "." ) toplabel [ "." ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet hostname = new BitSet(256);
+    // Static initializer for hostname
+    static {
+        hostname.or(toplabel);
+        // hostname.or(domainlabel);
+        hostname.set('.');
+    }
+
+
+    /**
+     * BitSet for host.
+     * <p><blockquote><pre>
+     * host          = hostname | IPv4address | IPv6reference
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet host = new BitSet(256);
+    // Static initializer for host
+    static {
+        host.or(hostname);
+        // host.or(IPv4address);
+        host.or(IPv6reference); // IPv4address
+    }
+
+
+    /**
+     * BitSet for hostport.
+     * <p><blockquote><pre>
+     * hostport      = host [ ":" port ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet hostport = new BitSet(256);
+    // Static initializer for hostport
+    static {
+        hostport.or(host);
+        hostport.set(':');
+        hostport.or(port);
+    }
+
+
+    /**
+     * Bitset for userinfo.
+     * <p><blockquote><pre>
+     * userinfo      = *( unreserved | escaped |
+     *                    ";" | ":" | "&amp;" | "=" | "+" | "$" | "," )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet userinfo = new BitSet(256);
+    // Static initializer for userinfo
+    static {
+        userinfo.or(unreserved);
+        userinfo.or(escaped);
+        userinfo.set(';');
+        userinfo.set(':');
+        userinfo.set('&');
+        userinfo.set('=');
+        userinfo.set('+');
+        userinfo.set('$');
+        userinfo.set(',');
+    }
+
+
+    /**
+     * BitSet for within the userinfo component like user and password.
+     */
+    public static final BitSet within_userinfo = new BitSet(256);
+    // Static initializer for within_userinfo
+    static {
+        within_userinfo.or(userinfo);
+        within_userinfo.clear(';'); // reserved within authority
+        within_userinfo.clear(':');
+        within_userinfo.clear('@');
+        within_userinfo.clear('?');
+        within_userinfo.clear('/');
+    }
+
+
+    /**
+     * Bitset for server.
+     * <p><blockquote><pre>
+     * server        = [ [ userinfo "@" ] hostport ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet server = new BitSet(256);
+    // Static initializer for server
+    static {
+        server.or(userinfo);
+        server.set('@');
+        server.or(hostport);
+    }
+
+
+    /**
+     * BitSet for reg_name.
+     * <p><blockquote><pre>
+     * reg_name      = 1*( unreserved | escaped | "$" | "," |
+     *                     ";" | ":" | "@" | "&amp;" | "=" | "+" )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet reg_name = new BitSet(256);
+    // Static initializer for reg_name
+    static {
+        reg_name.or(unreserved);
+        reg_name.or(escaped);
+        reg_name.set('$');
+        reg_name.set(',');
+        reg_name.set(';');
+        reg_name.set(':');
+        reg_name.set('@');
+        reg_name.set('&');
+        reg_name.set('=');
+        reg_name.set('+');
+    }
+
+
+    /**
+     * BitSet for authority.
+     * <p><blockquote><pre>
+     * authority     = server | reg_name
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet authority = new BitSet(256);
+    // Static initializer for authority
+    static {
+        authority.or(server);
+        authority.or(reg_name);
+    }
+
+
+    /**
+     * BitSet for scheme.
+     * <p><blockquote><pre>
+     * scheme        = alpha *( alpha | digit | "+" | "-" | "." )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet scheme = new BitSet(256);
+    // Static initializer for scheme
+    static {
+        scheme.or(alpha);
+        scheme.or(digit);
+        scheme.set('+');
+        scheme.set('-');
+        scheme.set('.');
+    }
+
+
+    /**
+     * BitSet for rel_segment.
+     * <p><blockquote><pre>
+     * rel_segment   = 1*( unreserved | escaped |
+     *                     ";" | "@" | "&amp;" | "=" | "+" | "$" | "," )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet rel_segment = new BitSet(256);
+    // Static initializer for rel_segment
+    static {
+        rel_segment.or(unreserved);
+        rel_segment.or(escaped);
+        rel_segment.set(';');
+        rel_segment.set('@');
+        rel_segment.set('&');
+        rel_segment.set('=');
+        rel_segment.set('+');
+        rel_segment.set('$');
+        rel_segment.set(',');
+    }
+
+
+    /**
+     * BitSet for rel_path.
+     * <p><blockquote><pre>
+     * rel_path      = rel_segment [ abs_path ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet rel_path = new BitSet(256);
+    // Static initializer for rel_path
+    static {
+        rel_path.or(rel_segment);
+        rel_path.or(abs_path);
+    }
+
+
+    /**
+     * BitSet for net_path.
+     * <p><blockquote><pre>
+     * net_path      = "//" authority [ abs_path ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet net_path = new BitSet(256);
+    // Static initializer for net_path
+    static {
+        net_path.set('/');
+        net_path.or(authority);
+        net_path.or(abs_path);
+    }
+    
+
+    /**
+     * BitSet for hier_part.
+     * <p><blockquote><pre>
+     * hier_part     = ( net_path | abs_path ) [ "?" query ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet hier_part = new BitSet(256);
+    // Static initializer for hier_part
+    static {
+        hier_part.or(net_path);
+        hier_part.or(abs_path);
+        // hier_part.set('?'); aleady included
+        hier_part.or(query);
+    }
+
+
+    /**
+     * BitSet for relativeURI.
+     * <p><blockquote><pre>
+     * relativeURI   = ( net_path | abs_path | rel_path ) [ "?" query ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet relativeURI = new BitSet(256);
+    // Static initializer for relativeURI
+    static {
+        relativeURI.or(net_path);
+        relativeURI.or(abs_path);
+        relativeURI.or(rel_path);
+        // relativeURI.set('?'); aleady included
+        relativeURI.or(query);
+    }
+
+
+    /**
+     * BitSet for absoluteURI.
+     * <p><blockquote><pre>
+     * absoluteURI   = scheme ":" ( hier_part | opaque_part )
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet absoluteURI = new BitSet(256);
+    // Static initializer for absoluteURI
+    static {
+        absoluteURI.or(scheme);
+        absoluteURI.set(':');
+        absoluteURI.or(hier_part);
+        absoluteURI.or(opaque_part);
+    }
+
+
+    /**
+     * BitSet for URI-reference.
+     * <p><blockquote><pre>
+     * URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+     * </pre></blockquote><p>
+     */
+    protected static final BitSet URI_reference = new BitSet(256);
+    // Static initializer for URI_reference
+    static {
+        URI_reference.or(absoluteURI);
+        URI_reference.or(relativeURI);
+        URI_reference.set('#');
+        URI_reference.or(fragment);
+    }
+
+    // ---------------------------- Characters disallowed within the URI syntax
+    // Excluded US-ASCII Characters are like control, space, delims and unwise
+
+    /**
+     * BitSet for control.
+     */
+    public static final BitSet control = new BitSet(256);
+    // Static initializer for control
+    static {
+        for (int i = 0; i <= 0x1F; i++) {
+            control.set(i);
+        }
+        control.set(0x7F);
+    }
+
+    /**
+     * BitSet for space.
+     */
+    public static final BitSet space = new BitSet(256);
+    // Static initializer for space
+    static {
+        space.set(0x20);
+    }
+
+
+    /**
+     * BitSet for delims.
+     */
+    public static final BitSet delims = new BitSet(256);
+    // Static initializer for delims
+    static {
+        delims.set('<');
+        delims.set('>');
+        delims.set('#');
+        delims.set('%');
+        delims.set('"');
+    }
+
+
+    /**
+     * BitSet for unwise.
+     */
+    public static final BitSet unwise = new BitSet(256);
+    // Static initializer for unwise
+    static {
+        unwise.set('{');
+        unwise.set('}');
+        unwise.set('|');
+        unwise.set('\\');
+        unwise.set('^');
+        unwise.set('[');
+        unwise.set(']');
+        unwise.set('`');
+    }
+
+
+    /**
+     * Disallowed rel_path before escaping.
+     */
+    public static final BitSet disallowed_rel_path = new BitSet(256);
+    // Static initializer for disallowed_rel_path
+    static {
+        disallowed_rel_path.or(uric);
+        disallowed_rel_path.andNot(rel_path);
+    }
+
+
+    /**
+     * Disallowed opaque_part before escaping.
+     */
+    public static final BitSet disallowed_opaque_part = new BitSet(256);
+    // Static initializer for disallowed_opaque_part
+    static {
+        disallowed_opaque_part.or(uric);
+        disallowed_opaque_part.andNot(opaque_part);
+    }
+
+    // ----------------------- Characters allowed within and for each component
+
+    /**
+     * Those characters that are allowed for the authority component.
+     */
+    public static final BitSet allowed_authority = new BitSet(256);
+    // Static initializer for allowed_authority
+    static {
+        allowed_authority.or(authority);
+        allowed_authority.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed for the opaque_part.
+     */
+    public static final BitSet allowed_opaque_part = new BitSet(256);
+    // Static initializer for allowed_opaque_part 
+    static {
+        allowed_opaque_part.or(opaque_part);
+        allowed_opaque_part.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed for the reg_name.
+     */
+    public static final BitSet allowed_reg_name = new BitSet(256);
+    // Static initializer for allowed_reg_name 
+    static {
+        allowed_reg_name.or(reg_name);
+        // allowed_reg_name.andNot(percent);
+        allowed_reg_name.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed for the userinfo component.
+     */
+    public static final BitSet allowed_userinfo = new BitSet(256);
+    // Static initializer for allowed_userinfo
+    static {
+        allowed_userinfo.or(userinfo);
+        // allowed_userinfo.andNot(percent);
+        allowed_userinfo.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed for within the userinfo component.
+     */
+    public static final BitSet allowed_within_userinfo = new BitSet(256);
+    // Static initializer for allowed_within_userinfo
+    static {
+        allowed_within_userinfo.or(within_userinfo);
+        allowed_within_userinfo.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed for the IPv6reference component.
+     * The characters '[', ']' in IPv6reference should be excluded.
+     */
+    public static final BitSet allowed_IPv6reference = new BitSet(256);
+    // Static initializer for allowed_IPv6reference
+    static {
+        allowed_IPv6reference.or(IPv6reference);
+        // allowed_IPv6reference.andNot(unwise);
+        allowed_IPv6reference.clear('[');
+        allowed_IPv6reference.clear(']');
+    }
+
+
+    /**
+     * Those characters that are allowed for the host component.
+     * The characters '[', ']' in IPv6reference should be excluded.
+     */
+    public static final BitSet allowed_host = new BitSet(256);
+    // Static initializer for allowed_host
+    static {
+        allowed_host.or(hostname);
+        allowed_host.or(allowed_IPv6reference);
+    }
+
+
+    /**
+     * Those characters that are allowed for the authority component.
+     */
+    public static final BitSet allowed_within_authority = new BitSet(256);
+    // Static initializer for allowed_within_authority
+    static {
+        allowed_within_authority.or(server);
+        allowed_within_authority.or(reg_name);
+        allowed_within_authority.clear(';');
+        allowed_within_authority.clear(':');
+        allowed_within_authority.clear('@');
+        allowed_within_authority.clear('?');
+        allowed_within_authority.clear('/');
+    }
+
+
+    /**
+     * Those characters that are allowed for the abs_path.
+     */
+    public static final BitSet allowed_abs_path = new BitSet(256);
+    // Static initializer for allowed_abs_path
+    static {
+        allowed_abs_path.or(abs_path);
+        // allowed_abs_path.set('/');  // aleady included
+        allowed_abs_path.andNot(percent);
+        allowed_abs_path.clear('+');
+    }
+
+
+    /**
+     * Those characters that are allowed for the rel_path.
+     */
+    public static final BitSet allowed_rel_path = new BitSet(256);
+    // Static initializer for allowed_rel_path
+    static {
+        allowed_rel_path.or(rel_path);
+        allowed_rel_path.clear('%');
+        allowed_rel_path.clear('+');
+    }
+
+
+    /**
+     * Those characters that are allowed within the path.
+     */
+    public static final BitSet allowed_within_path = new BitSet(256);
+    // Static initializer for allowed_within_path
+    static {
+        allowed_within_path.or(abs_path);
+        allowed_within_path.clear('/');
+        allowed_within_path.clear(';');
+        allowed_within_path.clear('=');
+        allowed_within_path.clear('?');
+    }
+
+
+    /**
+     * Those characters that are allowed for the query component.
+     */
+    public static final BitSet allowed_query = new BitSet(256);
+    // Static initializer for allowed_query
+    static {
+        allowed_query.or(uric);
+        allowed_query.clear('%');
+    }
+
+
+    /**
+     * Those characters that are allowed within the query component.
+     */
+    public static final BitSet allowed_within_query = new BitSet(256);
+    // Static initializer for allowed_within_query
+    static {
+        allowed_within_query.or(allowed_query);
+        allowed_within_query.andNot(reserved); // excluded 'reserved'
+    }
+
+
+    /**
+     * Those characters that are allowed for the fragment component.
+     */
+    public static final BitSet allowed_fragment = new BitSet(256);
+    // Static initializer for allowed_fragment
+    static {
+        allowed_fragment.or(uric);
+        allowed_fragment.clear('%');
+    }
+
+    private URIBitSets() {
+    }
+
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIUtils.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIUtils.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.BitSet;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.vfs2.provider.GenericURLFileName;
+
+/**
+ * The URI escape and character encoding and decoding utility.
+ * <P>
+ * This was forked from some needed methods such as <code>#encodePath(...)</code> in <code>org.apache.commons.httpclient.util.URIUtil</code>,
+ * in order to not be dependent on HttpClient v3 API, when generating and handling {@link GenericURLFileName}s, 
+ * but it should work with any different HTTP backend provider implementations.
+ */
+public class URIUtils {
+
+    private static final Log LOG = LogFactory.getLog(URIUtils.class);
+
+    /**
+     * The default charset of the protocol.  RFC 2277, 2396
+     */
+    private static final String DEFAULT_PROTOCOL_CHARSET = "UTF-8";
+
+    private URIUtils() {
+    }
+
+    /**
+     * Escape and encode a string regarded as the path component of an URI with
+     * the default protocol charset.
+     *
+     * @param unescaped an unescaped string
+     * @return the escaped string
+     * 
+     * @throws URISyntaxException if the default protocol charset is not supported
+     */
+    public static String encodePath(String unescaped) throws URISyntaxException {
+        return encodePath(unescaped, DEFAULT_PROTOCOL_CHARSET);
+    }
+
+    /**
+     * Escape and encode a string regarded as the path component of an URI with
+     * a given charset.
+     *
+     * @param unescaped an unescaped string
+     * @param charset the charset
+     * @return the escaped string
+     * 
+     * @throws URISyntaxException if the charset is not supported
+     */
+    public static String encodePath(String unescaped, String charset) throws URISyntaxException {
+        if (unescaped == null) {
+            throw new IllegalArgumentException("The string to encode may not be null.");
+        }
+
+        return encode(unescaped, URIBitSets.allowed_abs_path, charset);
+    }
+
+    private static String encode(String unescaped, BitSet allowed, String charset) throws URISyntaxException {
+        byte[] rawdata = URLCodecUtils.encodeUrl(allowed, EncodingUtils.getBytes(unescaped, charset));
+        return EncodingUtils.getAsciiString(rawdata, 0, rawdata.length);
+    }
+
+    /**
+     * Internal URL codec utilities.
+     * <P>
+     * This was forked from some needed methods such as <code>#encodeUrl(...)</code> and <code>#hexDigit(int)</code>
+     * in <code>org.apache.commons.codec.net.URLCodec</code>, as commons-codec library cannot be pulled in transitively
+     * via Http Client v3 library any more.
+     */
+    private static class URLCodecUtils {
+
+        private static final byte ESCAPE_CHAR = '%';
+
+        private static final BitSet WWW_FORM_URL_SAFE = new BitSet(256);
+
+        // Static initializer for www_form_url
+        static {
+            // alpha characters
+            for (int i = 'a'; i <= 'z'; i++) {
+                WWW_FORM_URL_SAFE.set(i);
+            }
+            for (int i = 'A'; i <= 'Z'; i++) {
+                WWW_FORM_URL_SAFE.set(i);
+            }
+            // numeric characters
+            for (int i = '0'; i <= '9'; i++) {
+                WWW_FORM_URL_SAFE.set(i);
+            }
+            // special chars
+            WWW_FORM_URL_SAFE.set('-');
+            WWW_FORM_URL_SAFE.set('_');
+            WWW_FORM_URL_SAFE.set('.');
+            WWW_FORM_URL_SAFE.set('*');
+            // blank to be replaced with +
+            WWW_FORM_URL_SAFE.set(' ');
+        }
+
+        /**
+         * Radix used in encoding and decoding.
+         */
+        private static final int RADIX = 16;
+
+        private URLCodecUtils() {
+        }
+
+        static final byte[] encodeUrl(BitSet urlsafe, final byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
+            if (urlsafe == null) {
+                urlsafe = WWW_FORM_URL_SAFE;
+            }
+
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            for (final byte c : bytes) {
+                int b = c;
+                if (b < 0) {
+                    b = 256 + b;
+                }
+                if (urlsafe.get(b)) {
+                    if (b == ' ') {
+                        b = '+';
+                    }
+                    buffer.write(b);
+                } else {
+                    buffer.write(ESCAPE_CHAR);
+                    final char hex1 = hexDigit(b >> 4);
+                    final char hex2 = hexDigit(b);
+                    buffer.write(hex1);
+                    buffer.write(hex2);
+                }
+            }
+            return buffer.toByteArray();
+        }
+
+        private static char hexDigit(final int b) {
+            return Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
+        }
+    }
+
+    /**
+     * Internal character encoding utilities.
+     * <P>
+     * This was forked from some needed methods such as <code>#getBytes(...)</code> and <code>#getAsciiString(...)</code>
+     * in <code>org.apache.commons.httpclient.util.EncodingUtil</code>,
+     * in order to not be dependent on HttpClient v3 API, when generating and handling {@link GenericURLFileName}s, 
+     * but it should work with any different HTTP backend provider implementations.
+     */
+    private static class EncodingUtils {
+
+        private EncodingUtils() {
+        }
+
+        /**
+         * Converts the specified string to a byte array.  If the charset is not supported the
+         * default system charset is used.
+         *
+         * @param data the string to be encoded
+         * @param charset the desired character encoding
+         * @return The resulting byte array.
+         */
+        static byte[] getBytes(final String data, String charset) {
+            if (data == null) {
+                throw new IllegalArgumentException("data may not be null");
+            }
+
+            if (charset == null || charset.length() == 0) {
+                throw new IllegalArgumentException("charset may not be null or empty");
+            }
+
+            try {
+                return data.getBytes(charset);
+            } catch (UnsupportedEncodingException e) {
+
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("Unsupported encoding: " + charset + ". System encoding used.");
+                }
+
+                return data.getBytes();
+            }
+        }
+
+        /**
+         * Converts the byte array of ASCII characters to a string. This method is
+         * to be used when decoding content of HTTP elements (such as response
+         * headers)
+         *
+         * @param data the byte array to be encoded
+         * @param offset the index of the first byte to encode
+         * @param length the number of bytes to encode 
+         * @return The string representation of the byte array
+         */
+        static String getAsciiString(final byte[] data, int offset, int length) {
+            try {
+                return new String(data, offset, length, "US-ASCII");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException("US-ASCII charset is not supported.");
+            }
+        }
+    }
+
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.commons.vfs2.provider;
 
 import org.apache.commons.vfs2.FileObject;

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
@@ -32,6 +32,7 @@ import junit.framework.TestCase;
  */
 public class Http4FilesCacheTestCase extends TestCase {
 
+    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.vfs2.provider.http4.test;
 
-import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
@@ -29,9 +28,9 @@ import org.junit.Test;
 import junit.framework.TestCase;
 
 /**
- * Tests VFS-427 NPE on Http4FileObject.getContent().getContentInfo().
+ * Tests https://issues.apache.org/jira/browse/VFS-426.
  */
-public class Http4GetContentInfoTest extends TestCase {
+public class Http4FilesCacheTestCase extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
@@ -42,17 +41,23 @@ public class Http4GetContentInfoTest extends TestCase {
     }
 
     /**
-     * Tests VFS-427 NPE on Http4FileObject.getContent().getContentInfo().
-     *
-     * @throws FileSystemException thrown when the getContentInfo API fails.
+     * Tests https://issues.apache.org/jira/browse/VFS-426
      */
     @Test
-    public void testGetContentInfo() throws FileSystemException {
-        final FileSystemManager fsManager = VFS.getManager();
-        final FileObject fo = fsManager.resolveFile("http4://www.apache.org/licenses/LICENSE-2.0.txt");
-        final FileContent content = fo.getContent();
-        Assert.assertNotNull(content);
-        // Used to NPE before fix:
-        content.getContentInfo();
+    public void testQueryStringUrls() throws FileSystemException {
+        final String noQueryStringUrl = "http4://commons.apache.org/vfs";
+        final String queryStringUrl = "http4://commons.apache.org/vfs?query=string";
+        final String queryStringUrl2 = "http4://commons.apache.org/vfs?query=string&more=stuff";
+
+        final FileSystemManager fileSystemManager = VFS.getManager();
+
+        final FileObject noQueryFile = fileSystemManager.resolveFile(noQueryStringUrl);
+        Assert.assertEquals(noQueryStringUrl, noQueryFile.getURL().toExternalForm());
+
+        final FileObject queryFile = fileSystemManager.resolveFile(queryStringUrl);
+        Assert.assertEquals(queryStringUrl, queryFile.getURL().toExternalForm()); // failed for VFS-426
+
+        final FileObject queryFile2 = fileSystemManager.resolveFile(queryStringUrl2);
+        Assert.assertEquals(queryStringUrl2, queryFile2.getURL().toExternalForm()); // failed for VFS-426
     }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4FilesCacheTestCase.java
@@ -32,7 +32,7 @@ import junit.framework.TestCase;
  */
 public class Http4FilesCacheTestCase extends TestCase {
 
-    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
+    // TODO: VFS-360 - Remove this manual registration of http4 once http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4.test;
+
+import org.apache.commons.vfs2.FileContent;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.provider.http4.Http4FileProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests VFS-427 NPE on Http4FileObject.getContent().getContentInfo()
+ */
+public class Http4GetContentInfoTest extends TestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();
+        if (!manager.hasProvider("http4")) {
+            manager.addProvider("http4", new Http4FileProvider());
+        }
+    }
+
+    /**
+     * Tests VFS-427 NPE on Http4FileObject.getContent().getContentInfo().
+     *
+     * @throws FileSystemException thrown when the getContentInfo API fails.
+     */
+    @Test
+    public void testGetContentInfo() throws FileSystemException {
+        final FileSystemManager fsManager = VFS.getManager();
+        final FileObject fo = fsManager.resolveFile("http4://www.apache.org/licenses/LICENSE-2.0.txt");
+        final FileContent content = fo.getContent();
+        Assert.assertNotNull(content);
+        // Used to NPE before fix:
+        content.getContentInfo();
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
@@ -33,6 +33,7 @@ import junit.framework.TestCase;
  */
 public class Http4GetContentInfoTest extends TestCase {
 
+    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
@@ -33,7 +33,7 @@ import junit.framework.TestCase;
  */
 public class Http4GetContentInfoTest extends TestCase {
 
-    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
+    // TODO: VFS-360 - Remove this manual registration of http4 once http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
@@ -127,6 +127,7 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
         Assert.assertTrue(file.getChildren().length > 0);
     }
 
+    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
@@ -127,6 +127,14 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
         Assert.assertTrue(file.getChildren().length > 0);
     }
 
+    @Override
+    protected void setUp() throws Exception {
+        final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();
+        if (!manager.hasProvider("http4")) {
+            manager.addProvider("http4", new Http4FileProvider());
+        }
+    }
+
     /**
      * Returns the base folder for tests.
      */
@@ -144,7 +152,9 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
      */
     @Override
     public void prepare(final DefaultFileSystemManager manager) throws Exception {
-        manager.addProvider("http4", new Http4FileProvider());
+        if (!manager.hasProvider("http4")) {
+            manager.addProvider("http4", new Http4FileProvider());
+        }
     }
 
     private void testResloveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
@@ -127,7 +127,7 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
         Assert.assertTrue(file.getChildren().length > 0);
     }
 
-    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
+    // TODO: VFS-360 - Remove this manual registration of http4 once http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();
@@ -201,7 +201,7 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
         // ensure defaults are 0
         assertEquals(0, builder.getConnectionTimeout(opts));
         assertEquals(0, builder.getSoTimeout(opts));
-        assertEquals("Apache-Commons-VFS", builder.getUserAgent(opts));
+        assertEquals("Jakarta-Commons-VFS", builder.getUserAgent(opts));
 
         builder.setConnectionTimeout(opts, 60000);
         builder.setSoTimeout(opts, 60000);

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4ProviderTestCase.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.vfs2.FileNotFolderException;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.provider.http4.Http4FileProvider;
+import org.apache.commons.vfs2.provider.http4.Http4FileSystemConfigBuilder;
+import org.apache.commons.vfs2.test.AbstractProviderTestConfig;
+import org.apache.commons.vfs2.test.ProviderTestSuite;
+import org.apache.commons.vfs2.util.FreeSocketPortUtil;
+import org.apache.commons.vfs2.util.NHttpFileServer;
+import org.junit.Assert;
+
+import junit.framework.Test;
+
+/**
+ * Test cases for the HTTP4 provider.
+ *
+ */
+public class Http4ProviderTestCase extends AbstractProviderTestConfig {
+
+    private static NHttpFileServer Server;
+
+    private static int SocketPort;
+
+    private static final String TEST_URI = "test.http.uri";
+
+    /**
+     * Use %40 for @ in URLs
+     */
+    private static String ConnectionUri;
+
+    private static String getSystemTestUriOverride() {
+        return System.getProperty(TEST_URI);
+    }
+
+    /**
+     * Creates and starts an embedded Apache HTTP Server (HttpComponents).
+     *
+     * @throws Exception
+     */
+    private static void setUpClass() throws Exception {
+        Server = NHttpFileServer.start(SocketPort, new File(getTestDirectory()), 5000);
+    }
+
+    /**
+     * Creates a new test suite.
+     *
+     * @return a new test suite.
+     * @throws Exception Thrown when the suite cannot be constructed.
+     */
+    public static Test suite() throws Exception {
+        return new ProviderTestSuite(new Http4ProviderTestCase()) {
+            /**
+             * Adds base tests - excludes the nested test cases.
+             */
+            @Override
+            protected void addBaseTests() throws Exception {
+                super.addBaseTests();
+                addTests(Http4ProviderTestCase.class);
+            }
+
+            @Override
+            protected void setUp() throws Exception {
+                if (getSystemTestUriOverride() == null) {
+                    setUpClass();
+                }
+                super.setUp();
+            }
+
+            @Override
+            protected void tearDown() throws Exception {
+                tearDownClass();
+                super.tearDown();
+            }
+        };
+    }
+
+    /**
+     * Stops the embedded Apache HTTP Server.
+     *
+     * @throws IOException
+     */
+    private static void tearDownClass() throws IOException {
+        if (Server != null) {
+            Server.shutdown(5000, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Builds a new test case.
+     *
+     * @throws IOException Thrown if a free local socket port cannot be found.
+     */
+    public Http4ProviderTestCase() throws IOException {
+        SocketPort = FreeSocketPortUtil.findFreeLocalPort();
+        // Use %40 for @ in a URL
+        ConnectionUri = "http4://localhost:" + SocketPort;
+    }
+
+    private void checkReadTestsFolder(final FileObject file) throws FileSystemException {
+        Assert.assertNotNull(file.getChildren());
+        Assert.assertTrue(file.getChildren().length > 0);
+    }
+
+    /**
+     * Returns the base folder for tests.
+     */
+    @Override
+    public FileObject getBaseTestFolder(final FileSystemManager manager) throws Exception {
+        String uri = getSystemTestUriOverride();
+        if (uri == null) {
+            uri = ConnectionUri;
+        }
+        return manager.resolveFile(uri);
+    }
+
+    /**
+     * Prepares the file system manager.
+     */
+    @Override
+    public void prepare(final DefaultFileSystemManager manager) throws Exception {
+        manager.addProvider("http4", new Http4FileProvider());
+    }
+
+    private void testResloveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
+        VFS.getManager().getFilesCache().close();
+        final FileSystemOptions opts = new FileSystemOptions();
+        Http4FileSystemConfigBuilder.getInstance().setFollowRedirect(opts, followRedirect);
+        final FileObject file = VFS.getManager().resolveFile(uri, opts);
+        try {
+            checkReadTestsFolder(file);
+        } catch (final FileNotFolderException e) {
+            // Expected: VFS HTTP does not support listing children yet.
+        }
+    }
+
+    public void testResloveFolderSlashNoRedirectOff() throws FileSystemException {
+        testResloveFolderSlash(ConnectionUri + "/read-tests", false);
+    }
+
+    public void testResloveFolderSlashNoRedirectOn() throws FileSystemException {
+        testResloveFolderSlash(ConnectionUri + "/read-tests", true);
+    }
+
+    public void testResloveFolderSlashYesRedirectOff() throws FileSystemException {
+        testResloveFolderSlash(ConnectionUri + "/read-tests/", false);
+    }
+
+    public void testResloveFolderSlashYesRedirectOn() throws FileSystemException {
+        testResloveFolderSlash(ConnectionUri + "/read-tests/", true);
+    }
+
+    // Test no longer passing 2016/04/28
+    public void ignoreTestHttp405() throws FileSystemException {
+        final FileObject f = VFS.getManager()
+                .resolveFile("http4://www.w3schools.com/webservices/tempconvert.asmx?action=WSDL");
+        assert f.getContent().getSize() > 0;
+    }
+
+    /** Ensure VFS-453 options are present. */
+    public void testHttpTimeoutConfig() throws FileSystemException {
+        final FileSystemOptions opts = new FileSystemOptions();
+        final Http4FileSystemConfigBuilder builder = Http4FileSystemConfigBuilder.getInstance();
+
+        // ensure defaults are 0
+        assertEquals(0, builder.getConnectionTimeout(opts));
+        assertEquals(0, builder.getSoTimeout(opts));
+        assertEquals("Apache-Commons-VFS", builder.getUserAgent(opts));
+
+        builder.setConnectionTimeout(opts, 60000);
+        builder.setSoTimeout(opts, 60000);
+        builder.setUserAgent(opts, "foo/bar");
+
+        // ensure changes are visible
+        assertEquals(60000, builder.getConnectionTimeout(opts));
+        assertEquals(60000, builder.getSoTimeout(opts));
+        assertEquals("foo/bar", builder.getUserAgent(opts));
+
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4s.test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.commons.vfs2.FileContent;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.provider.http4.Http4FileProvider;
+import org.apache.commons.vfs2.provider.http4.Http4FileSystemConfigBuilder;
+import org.apache.commons.vfs2.provider.http4s.Http4sFileProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests VFS-427 NPE on HttpFileObject.getContent().getContentInfo()
+ */
+public class Http4sGetContentInfoTest extends TestCase {
+
+    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
+    @Override
+    protected void setUp() throws Exception {
+        final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();
+        if (!manager.hasProvider("http4")) {
+            manager.addProvider("http4", new Http4FileProvider());
+        }
+        if (!manager.hasProvider("http4s")) {
+            manager.addProvider("http4s", new Http4sFileProvider());
+        }
+    }
+
+    /**
+     * Tests VFS-427 NPE on HttpFileObject.getContent().getContentInfo().
+     *
+     * @throws FileSystemException thrown when the getContentInfo API fails.
+     * @throws MalformedURLException thrown when the System environment contains an invalid URL for an HTTPS proxy.
+     */
+    @Test
+    public void testGetContentInfo() throws FileSystemException, MalformedURLException {
+        String httpsProxyHost = null;
+        int httpsProxyPort = -1;
+        final String httpsProxy = System.getenv("https_proxy");
+        if (httpsProxy != null) {
+            final URL url = new URL(httpsProxy);
+            httpsProxyHost = url.getHost();
+            httpsProxyPort = url.getPort();
+        }
+        final FileSystemOptions opts;
+        if (httpsProxyHost != null) {
+            opts = new FileSystemOptions();
+            final Http4FileSystemConfigBuilder builder = Http4FileSystemConfigBuilder.getInstance();
+            builder.setProxyHost(opts, httpsProxyHost);
+            if (httpsProxyPort >= 0) {
+                builder.setProxyPort(opts, httpsProxyPort);
+            }
+        } else {
+            opts = null;
+        }
+
+        final FileSystemManager fsManager = VFS.getManager();
+        final FileObject fo = fsManager.resolveFile("http4://www.apache.org/licenses/LICENSE-2.0.txt", opts);
+        final FileContent content = fo.getContent();
+        Assert.assertNotNull(content);
+        // Used to NPE before fix:
+        content.getContentInfo();
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
@@ -39,7 +39,7 @@ import junit.framework.TestCase;
  */
 public class Http4sGetContentInfoTest extends TestCase {
 
-    // VFS-360: Keep this manual registration of http4 until http4 becomes part of standard providers.
+    // TODO: VFS-360 - Remove this manual registration of http4 once http4 becomes part of standard providers.
     @Override
     protected void setUp() throws Exception {
         final DefaultFileSystemManager manager = (DefaultFileSystemManager) VFS.getManager();

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,6 @@
         org.apache.jackrabbit.*;resolution:=optional,
         org.apache.tools.ant.*;resolution:=optional,
         org.apache.commons.httpclient.*;resolution:=optional,
-        org.apache.http.client.*;resolution:=optional,
         *
     </commons.osgi.import>
     <!-- Newer versions of clirr throw an NPE building the site -->

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore-nio</artifactId>
-        <version>4.4.9</version>
+        <version>4.4.10</version>
       </dependency>
       <!-- Test WebDAV with Apache Jackrabbit -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,14 @@
     <version.checkstyle>2.17</version.checkstyle>
     <!-- make sure bundle plugin has dependency informations for 'optional' -->
     <commons.osgi.excludeDependencies />
-	<commons.osgi.import>
-		org.apache.hadoop.*;resolution:=optional,
-		org.apache.jackrabbit.*;resolution:=optional,
-		org.apache.tools.ant.*;resolution:=optional,
-		org.apache.commons.httpclient.*;resolution:=optional,
-		*
-	</commons.osgi.import>
+    <commons.osgi.import>
+        org.apache.hadoop.*;resolution:=optional,
+        org.apache.jackrabbit.*;resolution:=optional,
+        org.apache.tools.ant.*;resolution:=optional,
+        org.apache.commons.httpclient.*;resolution:=optional,
+        org.apache.http.client.*;resolution:=optional,
+        *
+    </commons.osgi.import>
     <!-- Newer versions of clirr throw an NPE building the site -->
     <commons.clirr.version>2.6</commons.clirr.version>
     <!-- Avoid warnings about being unable to find jars during site building -->
@@ -408,6 +409,11 @@
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
         <version>3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Hi,

I submit a pull request to fix VFS-360.
It's now ready for VFS gurus to review! :-)

Here's a summary:

- Added `http4` and `http4s` providers using HttpComponents HttpClient v4.x library.
- All the unit tests were added and passed.
  As `http4*` are not in standard providers yet (providers.xml), unit tests contain manaul registrations to be removed later.
- Added `GenericURLFileName`/`GenericURLFileNameParser` and deprecated `URLFileName`/`URLFileName` because the latter set has a compile dependency on HttpClient v3 library. The former set now has no dependency on any specific libraries, and used in http4* providers.
  As part of this task, `org.apache.commons.vfs2.util.URIUtils` was introduced. It has some forked `#encodePath()` methods from HttpClient v3's `URIUtil`, `EncodingUtils` from HttpClient v3, and `URLCodecUtils#encodeUrl()` and `URIBitSets` from commons-codec. See their javadocs for detail.
- Use `URI` instead of `URL` as `URL` cannot parse file uri name starting with 'http4:' (`UrlFileProvider.java`).
- Added maven profiles to execute the `Shell` easily with a proper dependency set. e.g, `mvn -Pshell -Dhttp4`. See commons-vfs2-examples/README.md for details.
  Some example shell commands:

```
    $ cd commons-vfs2-examples
    $ mvn -Pshell -Dhttp4
    VFS Shell null
    cd http4://repo1.maven.org/maven2/org/apache/commons/commons-vfs2/
    cat maven-metadata.xml
    cd http4s://repo1.maven.org/maven2/org/apache/commons/commons-vfs2/
    cat maven-metadata.xml
```

- Also did some manual testing on basic authentication URI with a test web server. For example,

```
    $ cd commons-vfs2-examples
    $ mvn -Pshell -Dhttp4
    VFS Shell null
    cd http4://tester:secret@localhost:8888/folder1/
    cat README.txt
```

Thanks in advance,

Woonsan