### PR TITLE
[VFS-673] Support com.jcraft.jsch.ConfigRepository (~/.ssh/config) with SftpFileSystemConfigBuilder and flag to load OpenSSHConfig

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
@@ -255,7 +255,7 @@ vfs.provider.sftp/StrictHostKeyChecking-arg.error=Illegal argument "{0}" hostKey
 vfs.provider.sftp/unknown-modtime.error=Last modification time not fetched.
 vfs.provider.sftp/unknown-permissions.error=File permissions not fetched.
 vfs.provider.sftp/unknown-size.error=File size not fetched.
-vfs.provider.sftp/config-repository.error=Error during processing ConfigRepository.
+vfs.provider.sftp/load-openssh-config.error=Could not load openssh config.
 
 # URL Provider
 vfs.provider.url/badly-formed-uri.error=Badly formed URI "{0}".

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
@@ -255,6 +255,7 @@ vfs.provider.sftp/StrictHostKeyChecking-arg.error=Illegal argument "{0}" hostKey
 vfs.provider.sftp/unknown-modtime.error=Last modification time not fetched.
 vfs.provider.sftp/unknown-permissions.error=File permissions not fetched.
 vfs.provider.sftp/unknown-size.error=File size not fetched.
+vfs.provider.sftp/config-repository.error=Error during processing ConfigRepository.
 
 # URL Provider
 vfs.provider.url/badly-formed-uri.error=Badly formed URI "{0}".

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -17,28 +17,22 @@
 package org.apache.commons.vfs2.provider.sftp;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
 
+import com.jcraft.jsch.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.util.Os;
 
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Logger;
-import com.jcraft.jsch.Proxy;
-import com.jcraft.jsch.ProxyHTTP;
-import com.jcraft.jsch.ProxySOCKS5;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.UserInfo;
-
 /**
  * Create a JSch Session instance.
  */
 public final class SftpClientFactory {
     private static final String SSH_DIR_NAME = ".ssh";
+    private static final String OPENSSH_CONFIG_NAME = "config";
 
     private static final Log LOG = LogFactory.getLog(SftpClientFactory.class);
 
@@ -71,6 +65,8 @@ public final class SftpClientFactory {
         final File knownHostsFile = builder.getKnownHosts(fileSystemOptions);
         final IdentityInfo[] identities = builder.getIdentityInfo(fileSystemOptions);
         final IdentityRepositoryFactory repositoryFactory = builder.getIdentityRepositoryFactory(fileSystemOptions);
+        final ConfigRepository configRepository = builder.getConfigRepository(fileSystemOptions);
+        final boolean loadOpenSSHConfig = builder.isLoadOpenSSHConfig(fileSystemOptions);
 
         sshDir = findSshDir();
 
@@ -81,6 +77,7 @@ public final class SftpClientFactory {
         }
 
         addIdentities(jsch, sshDir, identities);
+        setConfigRepository(jsch, sshDir, configRepository, loadOpenSSHConfig);
 
         Session session;
         try {
@@ -161,6 +158,20 @@ public final class SftpClientFactory {
             final File privateKeyFile = new File(sshDir, "id_rsa");
             if (privateKeyFile.isFile() && privateKeyFile.canRead()) {
                 addIndentity(jsch, new IdentityInfo(privateKeyFile));
+            }
+        }
+    }
+
+    private static void setConfigRepository(final JSch jsch, final File sshDir, final ConfigRepository configRepository, boolean loadOpenSSHConfig) throws FileSystemException {
+        if (configRepository != null) {
+            jsch.setConfigRepository(configRepository);
+        } else if (loadOpenSSHConfig) {
+            try {
+                // Load the config repository (~/.ssh/config)
+                final ConfigRepository openSSHConfig = OpenSSHConfig.parseFile(new File(sshDir, OPENSSH_CONFIG_NAME).getAbsolutePath());
+                jsch.setConfigRepository(openSSHConfig);
+            } catch (IOException e) {
+                throw new FileSystemException("vfs.provider.sftp/config-repository.error", e);
             }
         }
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -20,12 +20,22 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
-import com.jcraft.jsch.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.util.Os;
+
+import com.jcraft.jsch.ConfigRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Logger;
+import com.jcraft.jsch.OpenSSHConfig;
+import com.jcraft.jsch.Proxy;
+import com.jcraft.jsch.ProxyHTTP;
+import com.jcraft.jsch.ProxySOCKS5;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UserInfo;
 
 /**
  * Create a JSch Session instance.
@@ -167,11 +177,11 @@ public final class SftpClientFactory {
             jsch.setConfigRepository(configRepository);
         } else if (loadOpenSSHConfig) {
             try {
-                // Load the config repository (~/.ssh/config)
+                // loading openssh config (~/.ssh/config)
                 final ConfigRepository openSSHConfig = OpenSSHConfig.parseFile(new File(sshDir, OPENSSH_CONFIG_NAME).getAbsolutePath());
                 jsch.setConfigRepository(openSSHConfig);
             } catch (IOException e) {
-                throw new FileSystemException("vfs.provider.sftp/config-repository.error", e);
+                throw new FileSystemException("vfs.provider.sftp/load-openssh-config.error", e);
             }
         }
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
@@ -24,6 +24,7 @@ import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 
+import com.jcraft.jsch.ConfigRepository;
 import com.jcraft.jsch.UserInfo;
 
 /**
@@ -95,6 +96,8 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final String HOST_KEY_CHECK_YES = "yes";
     private static final String IDENTITIES = _PREFIX + ".IDENTITIES";
     private static final String IDENTITY_REPOSITORY_FACTORY = _PREFIX + "IDENTITY_REPOSITORY_FACTORY";
+    private static final String CONFIG_REPOSITORY = _PREFIX + "CONFIG_REPOSITORY";
+    private static final String LOAD_OPENSSH_CONFIG = _PREFIX + "LOAD_OPENSSH_CONFIG";
     private static final String KNOWN_HOSTS = _PREFIX + ".KNOWN_HOSTS";
     private static final String PREFERRED_AUTHENTICATIONS = _PREFIX + ".PREFERRED_AUTHENTICATIONS";
     private static final String PROXY_COMMAND = _PREFIX + ".PROXY_COMMAND";
@@ -215,6 +218,29 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public IdentityRepositoryFactory getIdentityRepositoryFactory(final FileSystemOptions opts) {
         return (IdentityRepositoryFactory) this.getParam(opts, IDENTITY_REPOSITORY_FACTORY);
+    }
+
+    /**
+     * Get the config repository.
+     *
+     * @param opts The FileSystem options.
+     * @return the ConfigRepository
+     */
+    public ConfigRepository getConfigRepository(final FileSystemOptions opts) {
+        return (ConfigRepository) this.getParam(opts, CONFIG_REPOSITORY);
+    }
+
+    /**
+     * Returns {@link Boolean#TRUE} if VFS should load the OpenSSH config. Defaults to
+     * <code>Boolean.FALSE</code> if the method {@link #setLoadOpenSSHConfig(FileSystemOptions, boolean)} has not been
+     * invoked.
+     *
+     * @param opts The FileSystemOptions.
+     * @return <code>Boolean.TRUE</code> if VFS should load the OpenSSH config.
+     * @see #setLoadOpenSSHConfig
+     */
+    public boolean isLoadOpenSSHConfig(final FileSystemOptions opts) {
+        return this.getBoolean(opts, LOAD_OPENSSH_CONFIG, Boolean.FALSE);
     }
 
     /**
@@ -462,6 +488,21 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     /**
+     * Set the config repository. e.g. {@code /home/user/.ssh/config}.
+     * <p>
+     * This is useful when you want to use OpenSSHConfig.
+     *
+     * @param opts The FileSystem options.
+     * @param configRepository An config repository.
+     * @throws FileSystemException if an error occurs.
+     * @see <a href="http://www.jcraft.com/jsch/examples/OpenSSHConfig.java.html">OpenSSHConfig</a>
+     */
+    public void setConfigRepository(final FileSystemOptions opts, final ConfigRepository configRepository)
+            throws FileSystemException {
+        this.setParam(opts, CONFIG_REPOSITORY, configRepository);
+    }
+
+    /**
      * Sets the known_hosts file. e.g. {@code /home/user/.ssh/known_hosts2}.
      * <p>
      * We use {@link java.io.File} because JSch cannot deal with VFS FileObjects.
@@ -640,5 +681,15 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setUserInfo(final FileSystemOptions opts, final UserInfo info) {
         this.setParam(opts, UserInfo.class.getName(), info);
+    }
+
+    /**
+     * Sets the whether to load OpenSSH config.
+     *
+     * @param opts The FileSystem options.
+     * @param loadOpenSSHConfig true if the OpenSSH config should be loaded.
+     */
+    public void setLoadOpenSSHConfig(final FileSystemOptions opts, final boolean loadOpenSSHConfig) {
+        this.setParam(opts, LOAD_OPENSSH_CONFIG, loadOpenSSHConfig ? Boolean.TRUE : Boolean.FALSE);
     }
 }


### PR DESCRIPTION
Allow to set com.jcraft.jsch.ConfigRepository explicitly and flag to load OpenSSHConfig if the ConfigRepository was not provided.

[JSch-Examples-OpenSSHConfig](http://www.jcraft.com/jsch/examples/OpenSSHConfig.java.html)