### PR TITLE
Fix throwing exception on normal FTP stream close

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
@@ -264,6 +264,11 @@ public class FTPClientWrapper implements FtpClient {
     }
 
     @Override
+    public int getReplyCode() throws IOException {
+        return getFtpClient().getReplyCode();
+    }
+
+    @Override
     public String getReplyString() throws IOException {
         return getFtpClient().getReplyString();
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
@@ -53,5 +53,7 @@ public interface FtpClient {
 
     boolean abort() throws IOException;
 
+    int getReplyCode() throws IOException;
+
     String getReplyString() throws IOException;
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.net.ftp.FTPFile;
+import org.apache.commons.net.ftp.FTPReply;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileNotFolderException;
 import org.apache.commons.vfs2.FileObject;
@@ -582,7 +583,8 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
         protected void onClose() throws IOException {
             final boolean ok;
             try {
-                ok = client.completePendingCommand();
+                // See VFS-674 and the accompanying PR as to why this check for "transfer aborted" is needed
+                ok = client.completePendingCommand() || client.getReplyCode() == FTPReply.TRANSFER_ABORTED;
             } finally {
                 getAbstractFileSystem().putClient(client);
             }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/projects/VFS/issues/VFS-674.

For some reason, some FTP servers return `426` when you abort a download request before it has completed. You can see this happening with a FileZilla server:

`curl -v --range 0-499 ftp://ffmpeg:ffmpeg2018@ftp.pbteu.com/ExportHD.mpg --output -`

With the output being:

```
...
> RETR ExportHD.mpg
< 150 Opening data channel for file download from server of "/ExportHD.mpg"
* Maxdownload = 500
* Getting file with size: 500
* Remembering we are in dir ""
> ABOR
< 426 Connection closed; transfer aborted.
...
```

This PR handles cases like this.