### PR TITLE
setManager should be synchronized

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/VFS.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/VFS.java
@@ -96,7 +96,7 @@ public final class VFS {
      * @param manager the file system manager
      * @since 2.2
      */
-    public static void setManager(final FileSystemManager manager) {
+    public static synchronized void setManager(final FileSystemManager manager) {
         VFS.instance = manager;
     }
 }


### PR DESCRIPTION
Since `getManager` is synchronized to protect the `instance` resource,
so should the `setManager` since it operates on the same resource.