### PR TITLE
VFS-685 Modify FileInfo test class so it is usable in outside projects

### DIFF
--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/FileInfo.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/FileInfo.java
@@ -25,6 +25,7 @@ import org.apache.commons.vfs2.FileType;
  * Info about a file.
  */
 public class FileInfo {
+
     String baseName;
     FileType type;
     String content;
@@ -73,30 +74,37 @@ public class FileInfo {
         return child;
     }
 
-    public FileInfo addFileOrFolder(final String baseName) {
-        final FileInfo child = new FileInfo(baseName, FileType.FILE_OR_FOLDER, null);
-        addChild(child);
-        return child;
-    }
-
-    public FileInfo addFileOrFolder(final String baseName, final String content) {
-        final FileInfo child = new FileInfo(baseName, FileType.FILE_OR_FOLDER, content);
-        addChild(child);
-        return child;
-    }
-
+    /**
+     * Returns the base name for the file.
+     *
+     * @return the base name
+     */
     public String getBaseName() {
         return baseName;
     }
 
+    /**
+     * Returns the {@link FileType} of the file
+     *
+     * @return {@link FileType}
+     */
     public FileType getType() {
         return type;
     }
 
+    /**
+     * Returns file's content.
+     *
+     * @return the content as a {@code String}
+     */
     public String getContent() {
         return content;
     }
 
+    /**
+     * Returns a {@code Map} of this {@code FileInfo}'s children.
+     * @return the {@code FileInfo}'s children
+     */
     public Map<String, FileInfo> getChildren() {
         return children;
     }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/FileInfo.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/FileInfo.java
@@ -24,7 +24,7 @@ import org.apache.commons.vfs2.FileType;
 /**
  * Info about a file.
  */
-class FileInfo {
+public class FileInfo {
     String baseName;
     FileType type;
     String content;
@@ -71,5 +71,33 @@ class FileInfo {
         final FileInfo child = new FileInfo(baseName, FileType.FOLDER, null);
         addChild(child);
         return child;
+    }
+
+    public FileInfo addFileOrFolder(final String baseName) {
+        final FileInfo child = new FileInfo(baseName, FileType.FILE_OR_FOLDER, null);
+        addChild(child);
+        return child;
+    }
+
+    public FileInfo addFileOrFolder(final String baseName, final String content) {
+        final FileInfo child = new FileInfo(baseName, FileType.FILE_OR_FOLDER, content);
+        addChild(child);
+        return child;
+    }
+
+    public String getBaseName() {
+        return baseName;
+    }
+
+    public FileType getType() {
+        return type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Map<String, FileInfo> getChildren() {
+        return children;
     }
 }


### PR DESCRIPTION
Outside projects may not only run, but may extend the test classes in the project.  They cannot do so without the FileInfo class being public.