### PR TITLE
Fix monitor recursive except lost+found return null

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
@@ -37,6 +37,9 @@ import org.apache.commons.vfs2.util.RandomAccessMode;
  * A file object implementation which uses direct file access.
  */
 public class LocalFile extends AbstractFileObject<LocalFileSystem> {
+
+    private static final String[] EMPTY_STRING_ARGS = new String[0];
+
     private final String rootFile;
 
     private File file;
@@ -107,7 +110,8 @@ public class LocalFile extends AbstractFileObject<LocalFileSystem> {
      */
     @Override
     protected String[] doListChildren() throws Exception {
-        return UriParser.encode(file.list());
+        String[] files = file.list();
+        return UriParser.encode(files == null ? EMPTY_STRING_ARGS : files);
     }
 
     /**


### PR DESCRIPTION
When I use docker container to mount a directory,and the directory have another sub-mount.
I launch `DefaultFileMonitor`  and monitoring the parent-mount directory. It run healthy.
After I mount sub-mount. Virtual system will auto create lost+found directory but someone can't access.
```
            if (files == null) {
                // VFS-210
                // honor the new doListChildren contract
                // return null;
                throw new FileNotFolderException(fileName);
            } else if (files.length == 0) {
```
Program process this exception just try loop. It will cause dead loop.