### PR TITLE
Add support for customizing FTP transfer aborted status codes

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.net.ftp.FTPFile;
-import org.apache.commons.net.ftp.FTPReply;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileNotFolderException;
 import org.apache.commons.vfs2.FileObject;
@@ -50,7 +50,7 @@ import org.apache.commons.vfs2.util.RandomAccessMode;
  * An FTP file.
  */
 public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
-    
+
     private static final long DEFAULT_TIMESTAMP = 0L;
     private static final Map<String, FTPFile> EMPTY_FTP_FILE_MAP = Collections
             .unmodifiableMap(new TreeMap<String, FTPFile>());
@@ -100,7 +100,7 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
         doGetChildren();
 
         // Look for the requested child
-        // VFS-210 adds the null check. 
+        // VFS-210 adds the null check.
         return children != null ? children.get(name) : null;
     }
 
@@ -578,8 +578,7 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
         protected void onClose() throws IOException {
             final boolean ok;
             try {
-                // See VFS-674 and the accompanying PR as to why this check for "transfer aborted" is needed
-                ok = client.completePendingCommand() || client.getReplyCode() == FTPReply.TRANSFER_ABORTED;
+                ok = client.completePendingCommand() || isTransferAbortedOkStatusCode();
             } finally {
                 getAbstractFileSystem().putClient(client);
             }
@@ -587,6 +586,13 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
             if (!ok) {
                 throw new FileSystemException("vfs.provider.ftp/finish-get.error", getName());
             }
+        }
+
+        private boolean isTransferAbortedOkStatusCode() throws IOException {
+            List<Integer> transferAbortedOkStatusCodes = FtpFileSystemConfigBuilder
+                .getInstance()
+                .getTransferAbortedOkStatusCodes(getAbstractFileSystem().getFileSystemOptions());
+            return transferAbortedOkStatusCodes != null && transferAbortedOkStatusCodes.contains(client.getReplyCode());
         }
     }
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,9 @@ The <action> type attribute can be add,update,fix,remove.
 <!--        [Local] Need an easy way to convert from a FileObject to a File. -->
 <!--       </action> -->
 <!-- START Might need to be moved to the next version -->
+      <action issue="VFS-674" dev="ggregory" type="add" due-to="Boris Petrov, Gary Gregory">
+        Add support for customizing FTP transfer aborted status codes. GitHub #51.
+      </action>
       <action issue="VFS-690" dev="ggregory" type="add">
         Allow to set key exchange algorithm explicitly. GitHub #32.
       </action>


### PR DESCRIPTION
This is connected with [another PR I did a few months ago](https://github.com/apache/commons-vfs/pull/41). We hit yet **another** FTP that returns some strange status code when prematurely closing a stream - this one returns `550`.

This PR makes these status codes that should be treated as *OK* configurable with a default of `426` and `550` to handle such cases like the ones we've encountered.

P.S. Here is output from a `curl -v --range 0-499 "ftp://user:pass@192.168.40.224/dir/file.mpg" --output -` command:

```
...
> RETR file.mpg
< 125 Data connection already open; Transfer starting.
* Maxdownload = 500
* Getting file with size: 500
* Remembering we are in dir "dir/"
> ABOR
< 550 Data channel was closed by ABOR command from client.
* partial download completed, closing connection
> QUIT
< 226 ABOR command successful.
* Closing connection 0
```

P.S.2 This happens on a "Microsoft FTP Service":

```
...
220 Microsoft FTP Service
...
```

This is from the curl log.