### PR TITLE
Use parent group ids for all artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 *.iml
 *.iws
 .DS_Store
+
+.vscode/

--- a/commons-vfs2-distribution/pom.xml
+++ b/commons-vfs2-distribution/pom.xml
@@ -21,9 +21,7 @@ limitations under the License.
   <modelVersion>4.0.0</modelVersion>
 
   <name>Apache Commons VFS Distribution</name>
-  <groupId>org.apache.commons</groupId>
   <artifactId>commons-vfs2-distribution</artifactId>
-  <version>2.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Apache Commons VFS is a Virtual File System library - Distribution archives.</description>
 
@@ -46,50 +44,50 @@ limitations under the License.
       <id>release</id>
       <dependencies>
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2</artifactId>
           <version>${project.version}</version>
         </dependency>
 
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2</artifactId>
           <version>${project.version}</version>
           <classifier>sources</classifier>
         </dependency>
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2</artifactId>
           <version>${project.version}</version>
           <classifier>javadoc</classifier>
         </dependency>
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2</artifactId>
           <version>${project.version}</version>
           <classifier>tests</classifier>
         </dependency>
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2</artifactId>
           <version>${project.version}</version>
           <classifier>test-sources</classifier>
         </dependency>
 
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2-examples</artifactId>
           <version>${project.version}</version>
         </dependency>
 
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2-examples</artifactId>
           <version>${project.version}</version>
           <classifier>sources</classifier>
         </dependency>
         <dependency>
-          <groupId>org.apache.commons</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>commons-vfs2-examples</artifactId>
           <version>${project.version}</version>
           <classifier>javadoc</classifier>

--- a/commons-vfs2-examples/pom.xml
+++ b/commons-vfs2-examples/pom.xml
@@ -22,9 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>Apache Commons VFS Examples</name>
-  <groupId>org.apache.commons</groupId>
   <artifactId>commons-vfs2-examples</artifactId>
-  <version>2.4-SNAPSHOT</version>
   <description>Apache Commons VFS is a Virtual File System library - Examples.</description>
 
   <parent>
@@ -36,7 +34,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>
 

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -23,7 +23,6 @@
 
   <name>Apache Commons VFS</name>
   <artifactId>commons-vfs2</artifactId>
-  <version>2.4-SNAPSHOT</version>
   <description>Apache Commons VFS is a Virtual File System library.</description>
   <url>http://commons.apache.org/proper/commons-vfs/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -385,24 +385,24 @@
     <dependencies>
       <!-- artifacts of project, versions managed by release-plugin -->
       <dependency>
-        <groupId>org.apache.commons</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>commons-vfs2-sandbox</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>commons-vfs2-examples</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Hi, I'm the main contributor for this project https://github.com/abashev/vfs-s3 I have a lot of complaints about our 'custom' build for commons-vfs project so I've decided to submit everything that I have to common repo.
There is my first one - using parent group ids for all artifacts. I have to prepare own builds for commons-vfs so for me it is hard to track a lot of places with my group id. With this commit, I will be able to change only parent group id and leave everything as is.