### PR TITLE
Simplify adding files to DefaultFileMonitor

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileMonitor.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileMonitor.java
@@ -157,27 +157,6 @@ public class DefaultFileMonitor implements Runnable, FileMonitor {
      */
     @Override
     public void addFile(final FileObject file) {
-        doAddFile(file);
-        try {
-            // add all direct children too
-            if (file.getType().hasChildren()) {
-                // Traverse the children
-                final FileObject[] children = file.getChildren();
-                for (final FileObject element : children) {
-                    doAddFile(element);
-                }
-            }
-        } catch (final FileSystemException fse) {
-            LOG.error(fse.getLocalizedMessage(), fse);
-        }
-    }
-
-    /**
-     * Adds a file to be monitored.
-     *
-     * @param file The FileObject to add.
-     */
-    private void doAddFile(final FileObject file) {
         synchronized (this.monitorMap) {
             if (this.monitorMap.get(file.getName()) == null) {
                 this.monitorMap.put(file.getName(), new FileMonitorAgent(this, file));

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileMonitorTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileMonitorTests.java
@@ -149,6 +149,7 @@ public class DefaultFileMonitorTests extends AbstractVfsTestCase {
         final FileObject fileObj = fsManager.resolveFile(testDir.toURI().toURL().toString());
         final DefaultFileMonitor monitor = new DefaultFileMonitor(new TestFileListener());
         monitor.setDelay(2000);
+        monitor.setRecursive(true);
         monitor.addFile(fileObj);
         monitor.start();
         try {
@@ -164,6 +165,25 @@ public class DefaultFileMonitorTests extends AbstractVfsTestCase {
             Thread.sleep(3000);
             assertTrue("No event occurred", changeStatus != 0);
             assertTrue("Incorrect event " + changeStatus, changeStatus == 3);
+        } finally {
+            monitor.stop();
+        }
+    }
+
+    public void testChildFileDeletedWithoutRecursiveChecking() throws Exception {
+        writeToFile(testFile);
+        final FileObject fileObj = fsManager.resolveFile(testDir.toURI().toURL().toString());
+        final DefaultFileMonitor monitor = new DefaultFileMonitor(new TestFileListener());
+        monitor.setDelay(2000);
+        monitor.setRecursive(false);
+        monitor.addFile(fileObj);
+        monitor.start();
+        try {
+            changeStatus = 0;
+            Thread.sleep(300);
+            testFile.delete();
+            Thread.sleep(3000);
+            assertTrue("Event should not have occurred", changeStatus == 0);
         } finally {
             monitor.stop();
         }


### PR DESCRIPTION
The original code tried adding recursively the children twice - once in `doAddFile` and then again in `addFile` itself. This is now simplified.

Also fix a test which should work only in recursive mode and add another one.