### PR TITLE
VFS-609: VFS SFTP doesn't support a private key as byte array

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
@@ -26,6 +26,8 @@ import java.io.File;
 public class IdentityInfo {
     private final File privateKey;
     private final File publicKey;
+    private final byte[] privateKeyBytes;
+    private final byte[] publicKeyBytes;
     private final byte[] passPhrase;
 
     /**
@@ -69,6 +71,43 @@ public class IdentityInfo {
         this.privateKey = privateKey;
         this.publicKey = publicKey;
         this.passPhrase = passPhrase;
+        this.privateKeyBytes = null;
+        this.publicKeyBytes = null;
+    }
+
+
+    /**
+     * Constructs an identity info with private and public key and passphrase for the private key.
+     * <p>
+     *
+     * @param privateKey Private key bytes
+     * @param publicKey The public key part used for connections with exchange of certificates (can be {@code null})
+     * @param passPhrase The passphrase to decrypt the private key (can be {@code null} if no passphrase is used)
+     * @since 2.1
+     */
+    public IdentityInfo(final byte[] privateKey, final byte[] publicKey, final byte[] passPhrase)
+    {
+        this.privateKey = null;
+        this.publicKey = null;
+        this.privateKeyBytes = privateKey;
+        this.publicKeyBytes = publicKey;
+        this.passPhrase = passPhrase;
+    }
+
+    /**
+     * Constructs an identity info with private and passphrase for the private key.
+     * <p>
+     *
+     * @param privateKey Private key bytes
+     * @param passPhrase The passphrase to decrypt the private key (can be {@code null} if no passphrase is used)
+     * @since 2.1
+     */
+    public IdentityInfo(final byte[] privateKey, final byte[] passPhrase) {
+        this.privateKey = null;
+        this.publicKey = null;
+        this.publicKeyBytes = null;
+        this.privateKeyBytes = privateKey;
+        this.passPhrase = passPhrase;
     }
 
     /**
@@ -99,5 +138,25 @@ public class IdentityInfo {
      */
     public byte[] getPassPhrase() {
         return passPhrase;
+    }
+
+    /**
+     * Get private key bytes.
+     *
+     * @return private key
+     */
+    public byte[] getPrivateKeyBytes()
+    {
+        return privateKeyBytes;
+    }
+
+    /**
+     * Get public key bytes.
+     *
+     * @return public key
+     */
+    public byte[] getPublicKeyBytes()
+    {
+        return publicKeyBytes;
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -170,13 +170,13 @@ public final class SftpClientFactory {
             throws FileSystemException {
         if (identities != null) {
             for (final IdentityInfo info : identities) {
-                addIndentity(jsch, info);
+                addIdentity(jsch, info);
             }
         } else {
             // Load the private key (rsa-key only)
             final File privateKeyFile = new File(sshDir, "id_rsa");
             if (privateKeyFile.isFile() && privateKeyFile.canRead()) {
-                addIndentity(jsch, new IdentityInfo(privateKeyFile));
+                addIdentity(jsch, new IdentityInfo(privateKeyFile));
             }
         }
     }
@@ -195,11 +195,17 @@ public final class SftpClientFactory {
         }
     }
 
-    private static void addIndentity(final JSch jsch, final IdentityInfo info) throws FileSystemException {
+    private static void addIdentity(final JSch jsch, final IdentityInfo info) throws FileSystemException {
         try {
-            final String privateKeyFile = info.getPrivateKey() != null ? info.getPrivateKey().getAbsolutePath() : null;
-            final String publicKeyFile = info.getPublicKey() != null ? info.getPublicKey().getAbsolutePath() : null;
-            jsch.addIdentity(privateKeyFile, publicKeyFile, info.getPassPhrase());
+            if (info.getPrivateKey() != null) {
+                final String privateKeyFile = info.getPrivateKey() != null ? info.getPrivateKey().getAbsolutePath() : null;
+                final String publicKeyFile = info.getPublicKey() != null ? info.getPublicKey().getAbsolutePath() : null;
+                jsch.addIdentity(privateKeyFile, publicKeyFile, info.getPassPhrase());
+            } else if (info.getPrivateKeyBytes() != null) {
+                jsch.addIdentity("PrivateKey", info.getPrivateKeyBytes(), info.getPublicKeyBytes(), info.getPassPhrase());
+            } else {
+                throw new FileSystemException("vfs.provider.sftp/load-private-key.error", info);
+            }
         } catch (final JSchException e) {
             throw new FileSystemException("vfs.provider.sftp/load-private-key.error", info, e);
         }


### PR DESCRIPTION
I really need feature with specifying private key in bytes. I guess that I'm not alone with this need.
Please, check my pull request. It's my first time making pull request in this project. If I made something wrong, I would be glad to hear your comments.
P.S. I took code changes from https://issues.apache.org/jira/browse/VFS-609 that stevezhuang attached to ticket, but that code wasn't placed to repo.