### PR TITLE
Use codecov.io for calculating code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@
 language: java
 sudo: false
 
+install: true
+
 jdk:
   - openjdk8
   - openjdk11
@@ -25,4 +27,5 @@ jdk:
   - oraclejdk11
 
 after_success:
-  - mvn -V -B -e clean cobertura:cobertura coveralls:report
+  - mvn -V -B -e jacoco:report
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Apache Commons VFS Project
 ===================
 
 [![Build Status](https://travis-ci.org/apache/commons-vfs.svg)](https://travis-ci.org/apache/commons-vfs)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-vfs/badge.svg)](https://coveralls.io/r/apache/commons-vfs)
+[![Coverage Status](https://codecov.io/gh/apache/commons-vfs/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/commons-vfs)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-vfs2/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-vfs2/)
 [![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-vfs2/2.3.svg)](https://javadoc.io/doc/org.apache.commons/commons-vfs2/2.3)
 

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <!-- to increase memory for tests on Travis CI -->
-            <argLine>-Xmx64m</argLine>
+            <argLine>${argLine} -Xmx64m</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -289,6 +289,18 @@
             <exclude>dist/target/**</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.3</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -362,14 +374,6 @@
           <aggregate>true</aggregate>
         </configuration>
       </plugin>
-      <!-- cobertura breaks because it cannot parse annotations in methods. -->
-      <!--
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${commons.cobertura.version}</version>
-      </plugin>
-      -->
       <!-- javancss breaks because it cannot parse annotations in methods. -->
       <!--
       <plugin>
@@ -630,7 +634,7 @@
           <configuration>
             <!-- -Xmx64m: increases memory for tests on Travis CI -->
             <!--  jdk.tls.client.protocols: For use of older protocol since DSA is no longer in the JRE -->
-            <argLine>-Xmx64m -Djdk.tls.client.protocols=TLSv1.2</argLine>
+            <argLine>${argLine} -Xmx64m -Djdk.tls.client.protocols=TLSv1.2</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
I have no relations with codecov.io but I think it could be useful for this project (I used it for a while for vfs-s3 and it works fine). There are a few pros for it

1. It looks like coverall never worked for commons-vfs
![image](https://user-images.githubusercontent.com/214171/57656435-fa103100-75e0-11e9-9464-a7ed2bb1d08c.png)
1. It looks like codecov more active in compare to coverall - more twitter followers, latest tweets and blog posts from May, codecov was a part of Github marketplace initial submission etc.
1. Don't need separated maven plugin - it supports jacoco reports and could be installed as one-liner inside travis.yaml