### PR TITLE
VFS-619 Fixes performance issue with SftpFileObject.getChildren()

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -68,23 +68,6 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
     }
 
     /**
-     * @throws FileSystemException if error occurs.
-     * @since 2.0
-     */
-    @Override
-    public void refresh() throws FileSystemException {
-        if (!inRefresh) {
-            try {
-                inRefresh = true;
-                super.refresh();
-                attrs = null;
-            } finally {
-                inRefresh = false;
-            }
-        }
-    }
-
-    /**
      * Determines the type of this file, returns null if the file does not exist.
      */
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -77,12 +77,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
             try {
                 inRefresh = true;
                 super.refresh();
-                try {
-                    attrs = null;
-                    getType();
-                } catch (final IOException e) {
-                    throw new FileSystemException(e);
-                }
+                attrs = null;
             } finally {
                 inRefresh = false;
             }


### PR DESCRIPTION
This PR removes an unnecessary invocation of `SftpObject.getType()` by `refresh()`. 

This invocation causes performance degradation of `SftpFileObject.getChildren()` when `CacheStrategy.ON_RESOLVE` is in use as this forces a call to `refresh()`, which in turn calls `getType()`, making an additional `stat()` call to the SFTP server for each child.