### PR TITLE
MonitorInputStream should not close the stream in "read"

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
@@ -85,8 +85,6 @@ public class MonitorInputStream extends BufferedInputStream {
             return ch;
         }
 
-        // End-of-stream
-        close();
         return EOF_CHAR;
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/DefaultFileContentTest.java
@@ -49,6 +49,7 @@ public class DefaultFileContentTest {
                         stream.mark(0);
                         final byte[] data = new byte[100];
                         stream.read(data, 0, 7);
+                        stream.read();
                         Assert.assertEquals(expected, new String(data).trim());
                         stream.reset();
                     }
@@ -74,6 +75,7 @@ public class DefaultFileContentTest {
                         stream.mark(0);
                         final byte[] data = new byte[100];
                         readCount = stream.read(data, 0, 7);
+                        stream.read();
                         Assert.assertEquals(readCount, 7);
                         Assert.assertEquals(expected, new String(data).trim());
                         readCount = stream.read(data, 8, 10);


### PR DESCRIPTION
Similar to https://github.com/apache/commons-vfs/pull/30. That PR fixed only the `read` overload which accepts a buffer but missed the one with no arguments. This PR fixes also the other case.

See https://issues.apache.org/jira/projects/VFS/issues/VFS-614.