### PR TITLE
VFS-727: Replaced VFS.getManager() calls to more local FileSystemManager access.

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -1393,7 +1393,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
                 @Override
                 public URL run() throws MalformedURLException, FileSystemException {
                     final StringBuilder buf = new StringBuilder();
-                    final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), fileName.getURI(), buf);
+                    final String scheme = UriParser.extractScheme(fileSystem.getContext().getFileSystemManager().getSchemes(), fileName.getURI(), buf);
                     return new URL(scheme, "", -1, buf.toString(),
                             new DefaultURLStreamHandler(fileSystem.getContext(), fileSystem.getFileSystemOptions()));
                 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/CompositeFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/CompositeFileProvider.java
@@ -53,7 +53,7 @@ public abstract class CompositeFileProvider extends AbstractFileProvider {
             throws FileSystemException {
         final StringBuilder buf = new StringBuilder(INITIAL_BUFSZ);
 
-        UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buf);
+        UriParser.extractScheme(getContext().getFileSystemManager().getSchemes(), uri, buf);
 
         final String[] schemes = getSchemes();
         for (final String scheme : schemes) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultURLStreamHandler.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultURLStreamHandler.java
@@ -67,7 +67,7 @@ public class DefaultURLStreamHandler extends URLStreamHandler {
 
             final String url = newURL.getName().getURI();
             final StringBuilder filePart = new StringBuilder();
-            final String protocolPart = UriParser.extractScheme(VFS.getManager().getSchemes(), url, filePart);
+            final String protocolPart = UriParser.extractScheme(context.getFileSystemManager().getSchemes(), url, filePart);
 
             setURL(u, protocolPart, "", -1, null, null, filePart.toString(), null, null);
         } catch (final FileSystemException fse) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/LayeredFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/LayeredFileNameParser.java
@@ -65,7 +65,7 @@ public class LayeredFileNameParser extends AbstractFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme
-        final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), fileName, name);
+        final String scheme = UriParser.extractScheme(context.getFileSystemManager().getSchemes(), fileName, name);
 
         // Extract the Layered file URI
         final String rootUriName = extractRootName(name);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileProvider.java
@@ -59,7 +59,7 @@ public class ResourceFileProvider extends AbstractFileProvider {
     public FileObject findFile(final FileObject baseFile, final String uri, final FileSystemOptions fileSystemOptions)
             throws FileSystemException {
         final StringBuilder buf = new StringBuilder(BUFFER_SIZE);
-        UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buf);
+        UriParser.extractScheme(getContext().getFileSystemManager().getSchemes(), uri, buf);
         final String resourceName = buf.toString();
 
         ClassLoader classLoader = ResourceFileSystemConfigBuilder.getInstance().getClassLoader(fileSystemOptions);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/temp/TemporaryFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/temp/TemporaryFileProvider.java
@@ -83,7 +83,7 @@ public class TemporaryFileProvider extends AbstractFileProvider implements Compa
             final FileSystemOptions properties) throws FileSystemException {
         // Parse the name
         final StringBuilder buffer = new StringBuilder(uri);
-        final String scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), uri, buffer);
+        final String scheme = UriParser.extractScheme(getContext().getFileSystemManager().getSchemes(), uri, buffer);
         UriParser.fixSeparators(buffer);
         UriParser.normalisePath(buffer);
         final String path = buffer.toString();


### PR DESCRIPTION
All except the call in org.apache.commons.vfs2.provider.HostFileNameParser have been replaced to locally reachable instances of FileSystemManager.
I have a change for HostFileNameParser, but it breaks the test cases which call parseUri without a context.