### PR TITLE
VFS-727: Replaced usage of VFS.getManager() for locally available FileSystemManager.

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileNameParser.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileNameParser.java
@@ -28,63 +28,62 @@ import org.apache.commons.vfs2.provider.VfsComponentContext;
  * Implementation for sftp. set default port to 139
  */
 public class SmbFileNameParser extends URLFileNameParser {
-	private static final SmbFileNameParser INSTANCE = new SmbFileNameParser();
+    private static final SmbFileNameParser INSTANCE = new SmbFileNameParser();
+    private static final int SMB_PORT = 139;
 
-	private static final int SMB_PORT = 139;
+    public SmbFileNameParser() {
+        super(SMB_PORT);
+    }
 
-	public SmbFileNameParser() {
-		super(SMB_PORT);
-	}
+    public static FileNameParser getInstance() {
+        return INSTANCE;
+    }
 
-	public static FileNameParser getInstance() {
-		return INSTANCE;
-	}
+    @Override
+    public FileName parseUri(final VfsComponentContext context, final FileName base, final String filename)
+            throws FileSystemException {
+        final StringBuilder name = new StringBuilder();
 
-	@Override
-	public FileName parseUri(final VfsComponentContext context, final FileName base, final String filename)
-			throws FileSystemException {
-		final StringBuilder name = new StringBuilder();
+        // Extract the scheme and authority parts
+        final Authority auth = extractToPath(context, filename, name);
 
-		// Extract the scheme and authority parts
-		final Authority auth = extractToPath(context, filename, name);
+        // extract domain
+        String username = auth.getUserName();
+        final String domain = extractDomain(username);
+        if (domain != null) {
+            username = username.substring(domain.length() + 1);
+        }
 
-		// extract domain
-		String username = auth.getUserName();
-		final String domain = extractDomain(username);
-		if (domain != null) {
-			username = username.substring(domain.length() + 1);
-		}
+        // Decode and adjust separators
+        UriParser.canonicalizePath(name, 0, name.length(), this);
+        UriParser.fixSeparators(name);
 
-		// Decode and adjust separators
-		UriParser.canonicalizePath(name, 0, name.length(), this);
-		UriParser.fixSeparators(name);
+        // Extract the share
+        final String share = UriParser.extractFirstElement(name);
+        if (share == null || share.length() == 0) {
+            throw new FileSystemException("vfs.provider.smb/missing-share-name.error", filename);
+        }
 
-		// Extract the share
-		final String share = UriParser.extractFirstElement(name);
-		if (share == null || share.length() == 0) {
-			throw new FileSystemException("vfs.provider.smb/missing-share-name.error", filename);
-		}
+        // Normalise the path. Do this after extracting the share name,
+        // to deal with things like smb://hostname/share/..
+        final FileType fileType = UriParser.normalisePath(name);
+        final String path = name.toString();
 
-		// Normalise the path. Do this after extracting the share name,
-		// to deal with things like smb://hostname/share/..
-		final FileType fileType = UriParser.normalisePath(name);
-		final String path = name.toString();
+        return new SmbFileName(auth.getScheme(), auth.getHostName(), auth.getPort(), username, auth.getPassword(),
+                domain, share, path, fileType);
+    }
 
-		return new SmbFileName(auth.getScheme(), auth.getHostName(), auth.getPort(), username, auth.getPassword(),
-				domain, share, path, fileType);
-	}
+    private String extractDomain(final String username) {
+        if (username == null) {
+            return null;
+        }
 
-	private String extractDomain(final String username) {
-		if (username == null) {
-			return null;
-		}
+        for (int i = 0; i < username.length(); i++) {
+            if (username.charAt(i) == '\\') {
+                return username.substring(0, i);
+            }
+        }
 
-		for (int i = 0; i < username.length(); i++) {
-			if (username.charAt(i) == '\\') {
-				return username.substring(0, i);
-			}
-		}
-
-		return null;
-	}
+        return null;
+    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/GenericURLFileNameParser.java
@@ -44,7 +44,7 @@ public class GenericURLFileNameParser extends HostFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme and authority parts
-        final Authority auth = extractToPath(fileName, name);
+        final Authority auth = extractToPath(context, fileName, name);
 
         // Extract the queryString
         final String queryString = UriParser.extractQueryString(name);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
@@ -18,6 +18,7 @@ package org.apache.commons.vfs2.provider;
 
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.util.Cryptor;
@@ -49,7 +50,7 @@ public class HostFileNameParser extends AbstractFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme and authority parts
-        final Authority auth = extractToPath(fileName, name);
+        final Authority auth = extractToPath(context, fileName, name);
 
         // Decode and normalise the file name
         UriParser.canonicalizePath(name, 0, name.length(), this);
@@ -69,11 +70,18 @@ public class HostFileNameParser extends AbstractFileNameParser {
      * @return Authority extracted host authority, never null.
      * @throws FileSystemException if authority cannot be extracted.
      */
-    protected Authority extractToPath(final String uri, final StringBuilder name) throws FileSystemException {
+    protected Authority extractToPath(final VfsComponentContext context, final String uri, final StringBuilder name) throws FileSystemException {
         final Authority auth = new Authority();
 
+        FileSystemManager fsm;
+        if (context != null) {
+        	fsm = context.getFileSystemManager();
+        } else {
+        	fsm = VFS.getManager();
+        }
+        
         // Extract the scheme
-        auth.scheme = UriParser.extractScheme(VFS.getManager().getSchemes(), uri, name);
+        auth.scheme = UriParser.extractScheme(fsm.getSchemes(), uri, name);
 
         // Expecting "//"
         if (name.length() < 2 || name.charAt(0) != '/' || name.charAt(1) != '/') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
@@ -73,7 +73,7 @@ public class HostFileNameParser extends AbstractFileNameParser {
     protected Authority extractToPath(final VfsComponentContext context, final String uri, final StringBuilder name) throws FileSystemException {
         final Authority auth = new Authority();
 
-        FileSystemManager fsm;
+        final FileSystemManager fsm;
         if (context != null) {
         	fsm = context.getFileSystemManager();
         } else {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/URLFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/URLFileNameParser.java
@@ -45,7 +45,7 @@ public class URLFileNameParser extends HostFileNameParser {
         final StringBuilder name = new StringBuilder();
 
         // Extract the scheme and authority parts
-        final Authority auth = extractToPath(fileName, name);
+        final Authority auth = extractToPath(context, fileName, name);
 
         // Extract the queryString
         final String queryString = UriParser.extractQueryString(name);

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -56,6 +56,9 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="VFS-704" dev="ggregory" type="fix" due-to="Boris Petrov, Gary Gregory">
         Some providers wrap their input/output streams twice in a BufferedInputStream.
       </action>
+      <action issue="VFS-727" dev="ggregory" type="fix" due-to="Michiel Hendriks, Gary Gregory">
+        Prevented creation of singleton file system manager from providers.
+      </action>
     </release>
     <release version="2.4.1" date="2019-08-10" description="Bug fix release.">
       <action issue="VFS-725" dev="ggregory" type="fix" due-to="Gary Gregory">


### PR DESCRIPTION
Addressed the call to VFS.getManager() in HostFileNameParser. 
To avoid needing to make big changes to the unit tests which call parseUri without a context I added a conditional to extractToPath to use the context when not-null, otherwise fallback to VFS.getManager(), to get the FileSystemManager.

This should resolve VFS-727.