### PR TITLE
[VFS-750] Fix backwards incompatibility in AbstractFileObject.getInputStream

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/SupplierThrowingException.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/SupplierThrowingException.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.util;
+
+@FunctionalInterface
+public interface SupplierThrowingException<T, E extends Exception> {
+    T get() throws E;
+}


### PR DESCRIPTION
A test for this should be written but this could happen later.

@garydgregory - please review, merge and release this as `2.5.1`.