### PR TITLE
fix bug for class not found:org.apache.commons.vfs2.provider.webdav.WebdavFileProvider

### DIFF
--- a/commons-vfs2-cleanroomtest/pom.xml
+++ b/commons-vfs2-cleanroomtest/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache Commons VFS Clean Room Test</name>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-vfs2-cleanroomtest</artifactId>
+    <version>2.6.1-SNAPSHOT</version>
+    <description>Clean Room Test for Apache Commons VFS</description>
+    <url>http://commons.apache.org/proper/commons-vfs/</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-vfs2</artifactId>
+            <version>2.6.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/commons-vfs2-cleanroomtest/src/test/java/org/apache/commons/vfs2/cleanroomtest/FileChangeEventTest.java
+++ b/commons-vfs2-cleanroomtest/src/test/java/org/apache/commons/vfs2/cleanroomtest/FileChangeEventTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.cleanroomtest;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class FileChangeEventTest {
+    @Test
+    public void getManagerTest() throws FileSystemException {
+        VFS.getManager();
+    }
+
+}

--- a/commons-vfs2-cleanroomtest/src/test/resources/log4j.properties
+++ b/commons-vfs2-cleanroomtest/src/test/resources/log4j.properties
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# @version $Id: log4j.properties 27216 2011-09-14 02:34:00Z ggregory $
+
+log4j.rootLogger=ERROR, Console
+#log4j.rootLogger=WARN, Console
+#log4j.rootLogger=INFO, Console
+#log4j.rootLogger=DEBUG, Console
+
+###############################################################################
+# The console log
+#
+# Documentation: http://logging.apache.org/log4j/docs/api/org/apache/log4j/ConsoleAppender.html
+#
+# To enable this appender, add its name to the log4j.rootLogger list
+
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.ImmediateFlush=true
+log4j.appender.Console.Target=System.out
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} [%t] %-5p: %m%n

--- a/commons-vfs2-cleanroomtest/src/test/resources/log4j2.xml
+++ b/commons-vfs2-cleanroomtest/src/test/resources/log4j2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<Configuration>
+
+  <Appenders>
+
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d [%t] %-5p %m%n"/>
+    </Console>
+
+  </Appenders>
+
+  <Loggers>
+
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
+
+  </Loggers>
+
+</Configuration>

--- a/commons-vfs2-cleanroomtest/src/test/resources/test.properties
+++ b/commons-vfs2-cleanroomtest/src/test/resources/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+one = 1
+two = 2

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
@@ -293,6 +293,13 @@ public class StandardFileSystemManager extends DefaultFileSystemManager {
     private void addProvider(final Element providerDef, final boolean isDefault) throws FileSystemException {
         final String classname = providerDef.getAttribute("class-name");
 
+        // Make sure the provider class itself is in classpath
+        if (!findClass(classname)) {
+            final String msg = Messages.getString("vfs.impl/skipping-provider-self.debug", classname);
+            VfsLog.debug(getLogger(), getLogger(), msg);
+            return;
+        }
+
         // Make sure all required schemes are available
         final String[] requiredSchemes = getRequiredSchemes(providerDef);
         for (final String requiredScheme : requiredSchemes) {

--- a/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
@@ -165,6 +165,7 @@ vfs.impl/create-provider.error=Could not create file provider of class "{0}".
 vfs.impl/create-files-cache.error=Could not create files-cache implementation of class "{0}".
 vfs.impl/create-client-factory.error=Could not create client factory of class "{0}".
 vfs.impl/skipping-provider.debug=Skipping provider "{0}" because required class "{1}" is not available.
+vfs.impl/skipping-provider-self.debug=Skipping provider "{0}" because the class itself is not available.
 vfs.impl/skipping-provider-scheme.debug=Skipping provider "{0}" because required scheme "{1}" is not available.
 
 # FileTypeMap


### PR DESCRIPTION
1.fix bug for class not found:org.apache.commons.vfs2.provider.webdav.WebdavFileProvider since 2.5.0

this bug is caused by the remove of WebdavFileProvider, and when try to load WebdavFileProvider if the user does not have class WebdavFileProvider, then explode.

now the code will check the class as well as its dependency when load.(if the class itself does not exist then return)

2.add clean room test
This bug happened and even with this bug the tests now can pass.
that is because you include all things needed in test scope guys.
and we users do not usually include them all.
so when something went wrong and vfs can only run correctly when user code imports some repo(like this time), the current test mechanism can never tell.
So I add a clean room test for it.