### PR TITLE
bugfix webdav4s request urls

### DIFF
--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -219,16 +219,19 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
 
     private final Webdav4FileSystem fileSystem;
 
-    protected Webdav4FileObject(final AbstractFileName name, final Webdav4FileSystem fileSystem)
+    private final String requestScheme;
+
+    protected Webdav4FileObject(final AbstractFileName name, final Webdav4FileSystem fileSystem, final boolean ssl)
             throws FileSystemException, URISyntaxException {
-        this(name, fileSystem, Webdav4FileSystemConfigBuilder.getInstance());
+        this(name, fileSystem, ssl, Webdav4FileSystemConfigBuilder.getInstance());
     }
 
-    protected Webdav4FileObject(final AbstractFileName name, final Webdav4FileSystem fileSystem,
+    protected Webdav4FileObject(final AbstractFileName name, final Webdav4FileSystem fileSystem, final boolean ssl,
             final Webdav4FileSystemConfigBuilder builder) throws FileSystemException, URISyntaxException {
         super(name, fileSystem, builder);
         this.fileSystem = fileSystem;
         this.builder = builder;
+        this.requestScheme = ssl ? "https" : "http";
     }
 
     /**
@@ -614,7 +617,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             user = name.getUserName();
             password = name.getPassword();
         }
-        final GenericURLFileName newFile = new GenericURLFileName("http", name.getHostName(), name.getPort(), name.getDefaultPort(),
+        final GenericURLFileName newFile = new GenericURLFileName(requestScheme, name.getHostName(), name.getPort(), name.getDefaultPort(),
                 user, password, name.getPath(), name.getType(), name.getQueryString());
         try {
             return newFile.getURIEncoded(this.getUrlCharset());

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileProvider.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileProvider.java
@@ -82,8 +82,7 @@ public class Webdav4sFileProvider extends Http4sFileProvider {
             UserAuthenticatorUtils.cleanup(authData);
         }
 
-        return new Webdav4FileSystem(rootName, fsOpts, httpClient, httpClientContext) {
-        };
+        return new Webdav4sFileSystem(rootName, fsOpts, httpClient, httpClientContext);
     }
 
     @Override

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileSystem.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileSystem.java
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.vfs2.provider.webdav4;
-
-import java.net.URLStreamHandler;
-import java.util.Collection;
+package org.apache.commons.vfs2.provider.webdav4s;
 
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileName;
@@ -26,29 +23,25 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.DefaultURLStreamHandler;
 import org.apache.commons.vfs2.provider.http4.Http4FileSystem;
+import org.apache.commons.vfs2.provider.webdav4.Webdav4FileObject;
+import org.apache.commons.vfs2.provider.webdav4.Webdav4FileProvider;
+import org.apache.commons.vfs2.provider.webdav4.Webdav4FileSystem;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.protocol.HttpClientContext;
+
+import java.net.URLStreamHandler;
+import java.util.Collection;
 
 /**
  * A WebDAV file system based on HTTP4.
  *
  * @since 2.5.0
  */
-public class Webdav4FileSystem extends Http4FileSystem {
+public class Webdav4sFileSystem extends Webdav4FileSystem {
 
-    protected Webdav4FileSystem(final FileName rootName, final FileSystemOptions fileSystemOptions,
+    protected Webdav4sFileSystem(final FileName rootName, final FileSystemOptions fileSystemOptions,
             final HttpClient httpClient, final HttpClientContext httpClientContext) {
         super(rootName, fileSystemOptions, httpClient, httpClientContext);
-    }
-
-    /**
-     * Returns the capabilities of this file system.
-     *
-     * @param caps The Capabilities to add.
-     */
-    @Override
-    protected void addCapabilities(final Collection<Capability> caps) {
-        caps.addAll(Webdav4FileProvider.capabilities);
     }
 
     /**
@@ -59,15 +52,6 @@ public class Webdav4FileSystem extends Http4FileSystem {
      */
     @Override
     protected FileObject createFile(final AbstractFileName name) throws Exception {
-        return new Webdav4FileObject(name, this,false);
-    }
-
-    /**
-     * Return a URLStreamHandler.
-     *
-     * @return The URLStreamHandler.
-     */
-    public URLStreamHandler getURLStreamHandler() {
-        return new DefaultURLStreamHandler(getContext(), getFileSystemOptions());
+        return new Webdav4FileObject(name, this,true){};
     }
 }

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileSystem.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4s/Webdav4sFileSystem.java
@@ -35,7 +35,7 @@ import java.util.Collection;
 /**
  * A WebDAV file system based on HTTP4.
  *
- * @since 2.5.0
+ * @since 2.7.0
  */
 public class Webdav4sFileSystem extends Webdav4FileSystem {
 
@@ -52,6 +52,6 @@ public class Webdav4sFileSystem extends Webdav4FileSystem {
      */
     @Override
     protected FileObject createFile(final AbstractFileName name) throws Exception {
-        return new Webdav4FileObject(name, this,true){};
+        return new Webdav4FileObject(name, this, true){};
     }
 }


### PR DESCRIPTION
When using webdav4s the requests will be send as "http" and not "https".
So this will always fail when the webdav server does not allow "http" requests.
 