### PR TITLE
VFS-257 - FTP: Add support for MDTM to get more accurate last modified times

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
@@ -298,11 +298,13 @@ public class FTPClientWrapper implements FtpClient {
      * <p>
      * If this command is supported, the server will reply with a multi-line response where each line of 
      * the response contains an extended feature command supported by the server.
+     * </p>
      * 
      * @throws IOException If the underlying FTP client encountered an error
+     * @since 2.7.0
      */
     @Override
-    public boolean features() throws IOException {
+    public boolean getRemoteFtpFeatures() throws IOException {
         try {
             return getFtpClient().features();
         } catch (final IOException ex) {
@@ -317,10 +319,12 @@ public class FTPClientWrapper implements FtpClient {
      * regardless of what calendar may have been in use at the date and time the file was last modified.
      * <p>
      * NOTE: not all remote FTP servers support {@code MDTM}.
+     * </p>
      * 
      * @param relPath The relative path of the file object to execute {@code MDTM} command against
      * @return new {@code FTPFile} object containing the {@code MDTM} timestamp.
      * @throws IOException If the underlying FTP client encountered an error
+     * 
      */
     @Override
     public FTPFile mdtmFile(final String relPath) throws IOException {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
@@ -292,4 +292,24 @@ public class FTPClientWrapper implements FtpClient {
             return getFtpClient().storeFileStream(relPath);
         }
     }
+    
+    @Override
+    public boolean features() throws IOException {
+        try {
+            return getFtpClient().features();
+        } catch (final IOException ex) {
+            disconnect();
+            return getFtpClient().features();
+        }
+    }
+    
+    @Override
+    public FTPFile mdtmFile(final String relPath) throws IOException {
+        try {
+            return getFtpClient().mdtmFile(relPath);
+        } catch (final IOException ex) {
+            disconnect();
+            return getFtpClient().mdtmFile(relPath);
+        }
+    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
@@ -293,6 +293,14 @@ public class FTPClientWrapper implements FtpClient {
         }
     }
     
+    /**
+     * Determine what extended features the remote FTP server supports.
+     * <p>
+     * If this command is supported, the server will reply with a multi-line response where each line of 
+     * the response contains an extended feature command supported by the server.
+     * 
+     * @throws IOException If the underlying FTP client encountered an error
+     */
     @Override
     public boolean features() throws IOException {
         try {
@@ -303,6 +311,17 @@ public class FTPClientWrapper implements FtpClient {
         }
     }
     
+    /**
+     * The MDTM command is used to preserve a file's original date and time information after file transfer. It is typically
+     * more accurate than the {@code "LIST"} command response. Time values are always represented in UTC (GMT), and in the Gregorian calendar 
+     * regardless of what calendar may have been in use at the date and time the file was last modified.
+     * <p>
+     * NOTE: not all remote FTP servers support {@code MDTM}.
+     * 
+     * @param relPath The relative path of the file object to execute {@code MDTM} command against
+     * @return new {@code FTPFile} object containing the {@code MDTM} timestamp.
+     * @throws IOException If the underlying FTP client encountered an error
+     */
     @Override
     public FTPFile mdtmFile(final String relPath) throws IOException {
         try {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
@@ -69,5 +69,8 @@ public interface FtpClient {
     }
 
     OutputStream storeFileStream(String relPath) throws IOException;
-
+    
+    boolean features() throws IOException;
+    
+    FTPFile mdtmFile(final String relPath) throws IOException;
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
@@ -70,7 +70,13 @@ public interface FtpClient {
 
     OutputStream storeFileStream(String relPath) throws IOException;
     
-    boolean features() throws IOException;
+    default boolean features() throws IOException {
+        // Backward compatibility: return false ("FEAT" not supported)
+        return false;
+    }
     
-    FTPFile mdtmFile(final String relPath) throws IOException;
+    default FTPFile mdtmFile(final String relPath) throws IOException {
+        // Backward compatibility: return empty FTPFile
+        return new FTPFile();
+    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClient.java
@@ -70,11 +70,17 @@ public interface FtpClient {
 
     OutputStream storeFileStream(String relPath) throws IOException;
     
-    default boolean features() throws IOException {
+    /**
+     * @since 2.7.0
+     */
+    default boolean getRemoteFtpFeatures() throws IOException {
         // Backward compatibility: return false ("FEAT" not supported)
         return false;
     }
     
+    /**
+     * @since 2.7.0
+     */
     default FTPFile mdtmFile(final String relPath) throws IOException {
         // Backward compatibility: return empty FTPFile
         return new FTPFile();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -544,7 +544,7 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
     }
     
     /**
-     * Get the more accurate MDTM lastmodified file timestamp if supported by the remote FTP server.
+     * Gets the more accurate MDTM lastmodified file timestamp if supported by the remote FTP server.
      * 
      * @return the MDTM timestamp in milliseconds if supported, otherwise {@link #DEFAULT_TIMESTAMP}.
      * @throws Exception If an error occurred in underlying FTP client when either determining if
@@ -578,7 +578,7 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
     private boolean isMdtmSupported() throws Exception {
         final FtpClient client = getAbstractFileSystem().getClient();
         try {
-            if (client.features()) {
+            if (client.getRemoteFtpFeatures()) {
                 final String replyStr = client.getReplyString();
                 return replyStr.contains(FTPCmd.MDTM.getCommand());
             }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderMdtmTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderMdtmTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.ftp.test;
+
+import org.apache.commons.vfs2.test.LastModifiedTests;
+
+import junit.framework.Test;
+
+public class FtpProviderMdtmTestCase extends FtpProviderTestCase {
+    
+    /**
+     * MDTM is supported by default for underlying apache MINA ftpserver
+     */
+    public static Test suite() throws Exception {
+        return suite(new FtpProviderTestCase(), LastModifiedTests.class);
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderNoMdtmTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderNoMdtmTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.ftp.test;
+
+import java.io.IOException;
+
+import org.apache.commons.vfs2.test.LastModifiedTests;
+import org.apache.ftpserver.command.Command;
+import org.apache.ftpserver.command.CommandFactory;
+import org.apache.ftpserver.command.CommandFactoryFactory;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.FtpReply;
+import org.apache.ftpserver.ftplet.FtpRequest;
+import org.apache.ftpserver.impl.FtpIoSession;
+import org.apache.ftpserver.impl.FtpReplyTranslator;
+import org.apache.ftpserver.impl.FtpServerContext;
+import org.apache.ftpserver.impl.LocalizedFtpReply;
+
+import junit.framework.Test;
+
+public class FtpProviderNoMdtmTestCase extends FtpProviderTestCase {
+
+    public static Test suite() throws Exception {
+        return suite(new FtpProviderNoMdtmTestCase(), LastModifiedTests.class);
+    }
+    
+    /**
+     * Explicitly remove MDTM feature from underlying apache MINA ftp server so
+     * we can fallback to LIST timestamp (existing default behaviour).
+     */
+    @Override
+    protected CommandFactory getFtpCommandFactory() {
+        final CommandFactoryFactory factory = new CommandFactoryFactory();
+        factory.addCommand("FEAT", new Command() {
+            
+            @Override
+            public void execute(FtpIoSession session, FtpServerContext context, FtpRequest request)
+                    throws IOException, FtpException {
+                session.resetState();
+                
+                final String replyMsg = FtpReplyTranslator.translateMessage(session, request, context, 
+                        FtpReply.REPLY_211_SYSTEM_STATUS_REPLY, "FEAT", null);
+                final LocalizedFtpReply reply = new LocalizedFtpReply(FtpReply.REPLY_211_SYSTEM_STATUS_REPLY, replyMsg.replaceFirst(" MDTM\\n", ""));
+                
+                session.write(reply);
+            }
+        });
+        return factory.createCommandFactory();
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/FtpProviderTestCase.java
@@ -31,6 +31,7 @@ import org.apache.commons.vfs2.test.ProviderTestSuite;
 import org.apache.commons.vfs2.util.FreeSocketPortUtil;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.command.CommandFactory;
 import org.apache.ftpserver.ftplet.FileSystemFactory;
 import org.apache.ftpserver.ftplet.FtpException;
 import org.apache.ftpserver.ftplet.UserManager;
@@ -84,7 +85,7 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
      * @throws FtpException
      * @throws IOException
      */
-    static void setUpClass(final String rootDirectory, final FileSystemFactory fileSystemFactory)
+    static void setUpClass(final String rootDirectory, final FileSystemFactory fileSystemFactory, final CommandFactory ftpCmdFactory)
             throws FtpException, IOException {
         if (Server != null) {
             return;
@@ -104,6 +105,9 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
         serverFactory.setUserManager(userManager);
         if (fileSystemFactory != null) {
             serverFactory.setFileSystem(fileSystemFactory);
+        }
+        if (ftpCmdFactory != null) {
+            serverFactory.setCommandFactory(ftpCmdFactory);
         }
         final ListenerFactory factory = new ListenerFactory();
         // set the port of the listener
@@ -127,12 +131,12 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
     /**
      * Creates the test suite for subclasses of the ftp file system.
      */
-    protected static Test suite(final FtpProviderTestCase testCase) throws Exception {
+    protected static Test suite(final FtpProviderTestCase testCase, final Class<?>... testsToRun) throws Exception {
         return new ProviderTestSuite(testCase) {
             @Override
             protected void setUp() throws Exception {
                 if (getSystemTestUriOverride() == null) {
-                    setUpClass(testCase.getFtpRootDir(), testCase.getFtpFileSystem());
+                    setUpClass(testCase.getFtpRootDir(), testCase.getFtpFileSystem(), testCase.getFtpCommandFactory());
                 }
                 super.setUp();
             }
@@ -147,6 +151,17 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
                     super.tearDown();
                 } finally {
                     tearDownClass();
+                }
+            }
+            
+            @Override
+            protected void addBaseTests() throws Exception {
+                if (testsToRun.length == 0) {
+                    super.addBaseTests();
+                } else {
+                    for (final Class<?> test : testsToRun) {
+                        addTests(test);
+                    }
                 }
             }
         };
@@ -203,6 +218,10 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
      */
     protected String getFtpRootDir() {
         return getTestDirectory();
+    }
+    
+    protected CommandFactory getFtpCommandFactory() {
+        return null;
     }
 
     /**

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/MultipleConnectionTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/test/MultipleConnectionTestCase.java
@@ -33,7 +33,7 @@ public class MultipleConnectionTestCase {
 
     @BeforeClass
     public static void setUpClass() throws FtpException, IOException {
-        FtpProviderTestCase.setUpClass(FtpProviderTestCase.getTestDirectory(), null);
+        FtpProviderTestCase.setUpClass(FtpProviderTestCase.getTestDirectory(), null, null);
     }
 
     @AfterClass


### PR DESCRIPTION
Adding support for MDTM command when obtaining a FtpFileObject timestamp.

The patch attached on the original JIRA was quite old, so I started fresh.

Contains two test cases:
- Server supporting MDTM command
- Server not supporting MDTM command