### PR TITLE
VFS-758: resolve url scheme by its internaly-resolved uri scheme

### DIFF
--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -232,6 +232,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         this.builder = builder;
     }
 
+    // For the unit test to access this.
     @Override
     protected URI getInternalURI() throws FileSystemException {
         return super.getInternalURI();

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -229,6 +230,11 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         super(name, fileSystem, builder);
         this.fileSystem = fileSystem;
         this.builder = builder;
+    }
+
+    @Override
+    protected URI getInternalURI() throws FileSystemException {
+        return super.getInternalURI();
     }
 
     /**
@@ -614,9 +620,11 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             user = name.getUserName();
             password = name.getPassword();
         }
-        final GenericURLFileName newFile = new GenericURLFileName("http", name.getHostName(), name.getPort(), name.getDefaultPort(),
-                user, password, name.getPath(), name.getType(), name.getQueryString());
+
         try {
+            final GenericURLFileName newFile = new GenericURLFileName(getInternalURI().getScheme(), name.getHostName(),
+                    name.getPort(), name.getDefaultPort(), user, password, name.getPath(), name.getType(),
+                    name.getQueryString());
             return newFile.getURIEncoded(this.getUrlCharset());
         } catch (final Exception e) {
             return name.getURI();

--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObjectTest.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObjectTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.webdav4;
+
+import java.net.URI;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Webdav4FileObjectTest {
+
+    private static final String WEBDAV4_URL = "webdav4://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_WEBDAV4_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    private static final String WEBDAV4S_URL = "webdav4s://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_WEBDAV4S_URL = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    @Test
+    public void testWebdav4FileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(WEBDAV4_URL);
+
+        assertEquals(WEBDAV4_URL, file.getURL().toString());
+        assertTrue(file instanceof Webdav4FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Webdav4FileObject webdav4File = (Webdav4FileObject) file;
+        assertEquals(URI.create(INTERNAL_WEBDAV4_URL), webdav4File.getInternalURI());
+    }
+
+    @Test
+    public void testWebdav4sFileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(WEBDAV4S_URL);
+
+        assertEquals(WEBDAV4S_URL, file.getURL().toString());
+        assertTrue(file instanceof Webdav4FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Webdav4FileObject webdav4File = (Webdav4FileObject) file;
+        assertEquals(URI.create(INTERNAL_WEBDAV4S_URL), webdav4File.getInternalURI());
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FileObjectTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FileObjectTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http4;
+
+import java.net.URI;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Http4FileObjectTest {
+
+    private static final String HTTP4_URL = "http4://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_HTTP4_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    private static final String HTTP4S_URL = "http4s://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_HTTP4S_URL = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    @Test
+    public void testHttp4FileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(HTTP4_URL);
+
+        assertEquals(HTTP4_URL, file.getURL().toString());
+        assertTrue(file instanceof Http4FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Http4FileObject http4File = (Http4FileObject) file;
+        assertEquals(URI.create(INTERNAL_HTTP4_URL), http4File.getInternalURI());
+    }
+
+    @Test
+    public void testHttp4sFileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(HTTP4S_URL);
+
+        assertEquals(HTTP4S_URL, file.getURL().toString());
+        assertTrue(file instanceof Http4FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Http4FileObject http4File = (Http4FileObject) file;
+        assertEquals(URI.create(INTERNAL_HTTP4S_URL), http4File.getInternalURI());
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5FileObjectTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5FileObjectTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.http5;
+
+import java.net.URI;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Http5FileObjectTest {
+
+    private static final String HTTP5_URL = "http5://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_HTTP5_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    private static final String HTTP5S_URL = "http5s://www.apache.org/licenses/LICENSE-2.0.txt";
+    private static final String INTERNAL_HTTP5S_URL = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+    @Test
+    public void testHttp5FileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(HTTP5_URL);
+
+        assertEquals(HTTP5_URL, file.getURL().toString());
+        assertTrue(file instanceof Http5FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Http5FileObject http5File = (Http5FileObject) file;
+        assertEquals(URI.create(INTERNAL_HTTP5_URL), http5File.getInternalURI());
+    }
+
+    @Test
+    public void testHttp5sFileObjectURLs() throws FileSystemException {
+        final FileSystemManager fsm = VFS.getManager();
+        final FileObject file = fsm.resolveFile(HTTP5S_URL);
+
+        assertEquals(HTTP5S_URL, file.getURL().toString());
+        assertTrue(file instanceof Http5FileObject);
+
+        @SuppressWarnings("rawtypes")
+        final Http5FileObject http5File = (Http5FileObject) file;
+        assertEquals(URI.create(INTERNAL_HTTP5S_URL), http5File.getInternalURI());
+    }
+}


### PR DESCRIPTION
Hi @garydgregory ,
I think this will resolve the VFS-758, which is basically caused by the hard-coded "http" in Webdav4FileObject#toUrlString(GenericURLFileName, boolean), by which some webdav specific http invocation is done by resolving "internal" http(s) urls.
Regards,
Woonsan