### PR TITLE
Fix travis-ci to make allow_failures: - openjdk-ea due to https://jira.apache.org/jira/browse/VFS-765

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,12 @@ jdk:
   - openjdk11
   - openjdk12
   - openjdk13
-  - openjdk-ea
   - oraclejdk11
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea
 
 after_success:
   - mvn -V -B -e clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
this project cannot pass travis since Jul 22, 2019.
If you do care about the error on openjdk-ea, you shall fix it.
If you do not care, then shall add openjdk-ea to allow_failures.
It is not recommended to keep project failing travis for such a long time (several months till today.)