### PR TITLE
Fix for failed test cases when running with root

### DIFF
--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/CanReadFileFilterTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/CanReadFileFilterTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.vfs2.FileFilterSelector;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.util.Os;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -57,6 +58,8 @@ public class CanReadFileFilterTest extends BaseFilterTest {
 
     private static FileObject zipFileObj;
 
+    private static boolean isRootUser;
+
     @BeforeClass
     public static void beforeClass() throws IOException {
 
@@ -79,6 +82,7 @@ public class CanReadFileFilterTest extends BaseFilterTest {
         zipDir(testDir, "", zipFile);
         zipFileObj = getZipFileObject(zipFile);
 
+        isRootUser = (Os.isFamily(Os.OS_FAMILY_UNIX)) && (System.getProperty("user.name").trim().equals("root"));
     }
 
     @AfterClass
@@ -126,8 +130,10 @@ public class CanReadFileFilterTest extends BaseFilterTest {
     public void testAcceptReadOnly() throws FileSystemException {
 
         Assert.assertFalse(CanReadFileFilter.READ_ONLY.accept(writeableFileInfo));
-        Assert.assertTrue(CanReadFileFilter.READ_ONLY.accept(readOnlyFileInfo));
         Assert.assertFalse(CanReadFileFilter.READ_ONLY.accept(notExistingFileInfo));
+        if (!isRootUser) {
+            Assert.assertTrue(CanReadFileFilter.READ_ONLY.accept(readOnlyFileInfo));
+        }
 
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/CanWriteFileFilterTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/CanWriteFileFilterTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.vfs2.FileFilterSelector;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.util.Os;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -57,6 +58,8 @@ public class CanWriteFileFilterTest extends BaseFilterTest {
 
     private static FileObject zipFileObj;
 
+    private static boolean isRootUser;
+
     @BeforeClass
     public static void beforeClass() throws IOException {
 
@@ -78,6 +81,8 @@ public class CanWriteFileFilterTest extends BaseFilterTest {
         zipFile = new File(getTempDir(), CanWriteFileFilterTest.class.getName() + ".zip");
         zipDir(testDir, "", zipFile);
         zipFileObj = getZipFileObject(zipFile);
+
+        isRootUser = (Os.isFamily(Os.OS_FAMILY_UNIX)) && (System.getProperty("user.name").trim().equals("root"));
 
     }
 
@@ -108,8 +113,10 @@ public class CanWriteFileFilterTest extends BaseFilterTest {
     public void testAcceptCanWrite() throws FileSystemException {
 
         Assert.assertTrue(CanWriteFileFilter.CAN_WRITE.accept(writeableFileInfo));
-        Assert.assertFalse(CanWriteFileFilter.CAN_WRITE.accept(readOnlyFileInfo));
         Assert.assertTrue(CanWriteFileFilter.CAN_WRITE.accept(notExistingFileInfo));
+        if (!isRootUser) {
+            Assert.assertFalse(CanWriteFileFilter.CAN_WRITE.accept(readOnlyFileInfo));
+        }
 
     }
 
@@ -117,8 +124,10 @@ public class CanWriteFileFilterTest extends BaseFilterTest {
     public void testAcceptCannotWrite() throws FileSystemException {
 
         Assert.assertFalse(CanWriteFileFilter.CANNOT_WRITE.accept(writeableFileInfo));
-        Assert.assertTrue(CanWriteFileFilter.CANNOT_WRITE.accept(readOnlyFileInfo));
         Assert.assertFalse(CanWriteFileFilter.CANNOT_WRITE.accept(notExistingFileInfo));
+        if (!isRootUser) {
+            Assert.assertTrue(CanWriteFileFilter.CANNOT_WRITE.accept(readOnlyFileInfo));
+        }
 
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/PermissionsTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/PermissionsTests.java
@@ -23,6 +23,7 @@ import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.provider.local.LocalFileSystem;
+import org.apache.commons.vfs2.util.Os;
 import org.junit.Assert;
 
 /**
@@ -34,6 +35,8 @@ import org.junit.Assert;
  */
 public class PermissionsTests extends AbstractProviderTestCase {
     public static final String FILENAME = "permission.txt";
+    public static final boolean isRootUser =
+            (Os.isFamily(Os.OS_FAMILY_UNIX)) && (System.getProperty("user.name").trim().equals("root"));
 
     /**
      * Returns the capabilities required by the tests of this test case.
@@ -64,8 +67,10 @@ public class PermissionsTests extends AbstractProviderTestCase {
             Assert.assertTrue("File expected to be executable: " + file, file.isExecutable());
 
             // Clear the executable flag
-            Assert.assertTrue("Setting executable permission failed: " + file, file.setExecutable(false, true));
-            Assert.assertFalse("File expected to be not executable: " + file, file.isExecutable());
+            if (!isRootUser) {
+                Assert.assertTrue("Setting executable permission failed: " + file, file.setExecutable(false, true));
+                Assert.assertFalse("File expected to be not executable: " + file, file.isExecutable());
+            }
         }
     }
 
@@ -84,8 +89,10 @@ public class PermissionsTests extends AbstractProviderTestCase {
         Assert.assertTrue("File expected to be writable: " + file, file.isWriteable());
 
         // Clear the write permission
-        Assert.assertTrue("Setting write permission failed: " + file, file.setWritable(false, true));
-        Assert.assertFalse("File expected to be not writable: " + file, file.isWriteable());
+        if (!isRootUser) {
+            Assert.assertTrue("Setting write permission failed: " + file, file.setWritable(false, true));
+            Assert.assertFalse("File expected to be not writable: " + file, file.isWriteable());
+        }
     }
 
     /**
@@ -107,8 +114,10 @@ public class PermissionsTests extends AbstractProviderTestCase {
             Assert.assertTrue("File expected to be readable: " + file, file.isReadable());
 
             // Clear the readable permission
-            Assert.assertTrue("Setting read permission failed: " + file, file.setReadable(false, true));
-            Assert.assertFalse("File expected to be not readable: " + file, file.isReadable());
+            if (!isRootUser) {
+                Assert.assertTrue("Setting read permission failed: " + file, file.setReadable(false, true));
+                Assert.assertFalse("File expected to be not readable: " + file, file.isReadable());
+            }
         }
     }
 


### PR DESCRIPTION
Some tests are failed when running with root. This is a fix for them.