### PR TITLE
set openjdk14 to allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - jdk: openjdk11
     - jdk: openjdk12
     - jdk: openjdk13
+    - jdk: openjdk14
     - jdk: oraclejdk11
     - jdk: openjdk-ea
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,16 @@
 
 language: java
 sudo: false
-
-jdk:
-  - openjdk8
-  - openjdk11
-  - openjdk12
-  - openjdk13
-  - oraclejdk11
-  - openjdk-ea
-
 matrix:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk11
+    - jdk: openjdk12
+    - jdk: openjdk13
+    - jdk: oraclejdk11
+    - jdk: openjdk-ea
   allow_failures:
-    - jdk:
-        - openjdk14
-        - openjdk-ea
-
+    - jdk: openjdk14
+    - jdk: openjdk-ea
 after_success:
   - mvn -V -B -e clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ jdk:
   - openjdk11
   - openjdk12
   - openjdk13
-  - openjdk14
   - oraclejdk11
   - openjdk-ea
 
 matrix:
   allow_failures:
+    - jdk: openjdk14
     - jdk: openjdk-ea
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ jdk:
 
 matrix:
   allow_failures:
-    jdk:
-      - openjdk14
-      - openjdk-ea
+    - jdk:
+        - openjdk14
+        - openjdk-ea
 
 after_success:
   - mvn -V -B -e clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ jdk:
 
 matrix:
   allow_failures:
-    - jdk: openjdk14
-    - jdk: openjdk-ea
+    jdk:
+      - openjdk14
+      - openjdk-ea
 
 after_success:
   - mvn -V -B -e clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
Hi.
I don't think commons-vfs can pass travis-ci on jdk14.
the problem is at least in WebdavProviderTestCase, which use jackrabbit-standalone-1.6.5.
I also doubt the possibility for jackrabbit for passing tests on jdk14.

So as I am not familiar with jackrabbit, I can only put jdk14 into allow-failure for now.

I also suggest making jackrabbit on travis-ci.
I can help making travis-ci scripts for jackrabbit, but I'd prefer asking about it on mailing list before I take actions.
