### PR TITLE
[VFS-748] TarProvider Incorrectly marks file IMAGINARY after garbage collection with WeakRefFilesCache

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileSystem.java
@@ -19,11 +19,9 @@ package org.apache.commons.vfs2.provider.zip;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -79,7 +77,6 @@ public class ZipFileSystem extends AbstractFileSystem {
 
         try {
             // Build the index
-            final List<ZipFileObject> strongRef = new ArrayList<>(getZipFile().size());
             final Enumeration<? extends ZipEntry> entries = getZipFile().entries();
             while (entries.hasMoreElements()) {
                 final ZipEntry entry = entries.nextElement();
@@ -96,8 +93,6 @@ public class ZipFileSystem extends AbstractFileSystem {
 
                 fileObj = createZipFileObject(name, entry);
                 putFileToCache(fileObj);
-                strongRef.add(fileObj);
-                fileObj.holdObject(strongRef);
 
                 // Make sure all ancestors exist
                 // TODO - create these on demand
@@ -110,8 +105,6 @@ public class ZipFileSystem extends AbstractFileSystem {
                     if (parent == null) {
                         parent = createZipFileObject(parentName, null);
                         putFileToCache(parent);
-                        strongRef.add(parent);
-                        parent.holdObject(strongRef);
                     }
 
                     // Attach child to parent

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/test/TarFileSystemTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/test/TarFileSystemTestCase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.tar.test;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.cache.WeakRefFilesCache;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class TarFileSystemTestCase {
+
+    @Test
+    public void testTarFileUseWeakRefFilesCache() throws FileSystemException {
+        testUseWeakRefFilesCache("tar", "src/test/resources/test-data/test.tar");
+    }
+
+    @Test
+    public void testTgzFileUseWeakRefFilesCache() throws FileSystemException {
+        testUseWeakRefFilesCache("tgz", "src/test/resources/test-data/test.tgz");
+    }
+
+    @Test
+    public void testTbz2FileUseWeakRefFilesCache() throws FileSystemException {
+        testUseWeakRefFilesCache("tbz2", "src/test/resources/test-data/test.tbz2");
+    }
+
+    /**
+     * set file system's file cache use WeakReference, and test resolve file after gc
+     **/
+    private void testUseWeakRefFilesCache(String scheme, String filePath) throws FileSystemException {
+
+        String fileUri = scheme + ":file:" + new File(filePath).getAbsolutePath();
+        FileObject fileObject = null;
+
+        try (StandardFileSystemManager manager = new StandardFileSystemManager()) {
+            // set file system's file cache use WeakReference, and init file system
+            manager.setFilesCache(new WeakRefFilesCache());
+            manager.init();
+
+            int cnt = 0;
+            while (cnt < 100000) {
+                cnt++;
+
+                // resolve file, assert fileObject exist. clear fileObject to null and wait gc
+                fileObject = manager.resolveFile(fileUri);
+                Assert.assertTrue(fileObject.exists());
+                fileObject = null;
+
+                // every 200 times suggest one gc
+                if (cnt % 200 == 0) {
+                    System.gc();
+                }
+            }
+        }
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/zip/test/ZipFileSystemTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/zip/test/ZipFileSystemTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.zip.test;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.cache.WeakRefFilesCache;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class ZipFileSystemTestCase {
+
+    /**
+     * set file system's file cache use WeakReference, and test resolve file after gc
+     **/
+    @Test
+    public void testZipFileUseWeakRefFilesCache() throws FileSystemException {
+
+        File file = new File("src/test/resources/test-data/test.zip");
+        String fileUri = "zip:file:" + file.getAbsolutePath();
+        FileObject fileObject = null;
+
+        try (StandardFileSystemManager manager = new StandardFileSystemManager()) {
+            // set file system's file cache use WeakReference, and init file system
+            manager.setFilesCache(new WeakRefFilesCache());
+            manager.init();
+
+            int cnt = 0;
+            while (cnt < 100000) {
+                cnt++;
+
+                // resolve file, assert fileObject exist. clear fileObject to null and wait gc
+                fileObject = manager.resolveFile(fileUri);
+                Assert.assertTrue(fileObject.exists());
+                fileObject = null;
+
+                // every 200 times suggest one gc
+                if (cnt % 200 == 0) {
+                    System.gc();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix for the cache fail in TarFileSystem after garbage collection with weakRefFilesCache. Added a private field cache and removed the local variable strongRef. This is similiar to the cache design in ZipFileSystem.

And also removed the local variable strongRef in ZipFileSystem cause it seems not working at all.