### PR TITLE
Add fail-fast : false for github actions maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ 8, 11, 14 ]
         experimental: [false]


### PR DESCRIPTION
As it's described here : [workflow syntax for github actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)

`When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true`

I think we should continue our build process if some job was failed.