### PR TITLE
Add proxy config for some Http/Https test

### DIFF
--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/test/Http4GetContentInfoTest.java
@@ -20,11 +20,16 @@ import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.http4.Http4FileSystemConfigBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
 import junit.framework.TestCase;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Tests VFS-427 NPE on Http4FileObject.getContent().getContentInfo().
@@ -37,12 +42,37 @@ public class Http4GetContentInfoTest extends TestCase {
      * @throws FileSystemException thrown when the getContentInfo API fails.
      */
     @Test
-    public void testGetContentInfo() throws FileSystemException {
+    public void testGetContentInfo() throws FileSystemException, MalformedURLException {
         final FileSystemManager fsManager = VFS.getManager();
-        final FileObject fo = fsManager.resolveFile("http4://www.apache.org/licenses/LICENSE-2.0.txt");
+        final String uri = "http4://www.apache.org/licenses/LICENSE-2.0.txt";
+        final FileObject fo = fsManager.resolveFile(uri, getOptionsWithProxy());
         final FileContent content = fo.getContent();
         Assert.assertNotNull(content);
         // Used to NPE before fix:
         content.getContentInfo();
+    }
+
+    FileSystemOptions getOptionsWithProxy() throws MalformedURLException {
+        // get proxy host and port from env var "https_proxy"
+        String proxyHost = null;
+        int proxyPort = -1;
+        final String proxyUrl = System.getenv("https_proxy");
+        if (proxyUrl != null) {
+            final URL url = new URL(proxyUrl);
+            proxyHost = url.getHost();
+            proxyPort = url.getPort();
+        }
+
+        // return null if proxy host or port invalid
+        if (proxyHost == null || proxyPort == -1) {
+            return null;
+        }
+
+        // return options with proxy
+        final Http4FileSystemConfigBuilder builder = Http4FileSystemConfigBuilder.getInstance();
+        final FileSystemOptions opts = new FileSystemOptions();
+        builder.setProxyHost(opts, proxyHost);
+        builder.setProxyPort(opts, proxyPort);
+        return opts;
     }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4s/test/Http4sGetContentInfoTest.java
@@ -44,31 +44,36 @@ public class Http4sGetContentInfoTest extends TestCase {
      */
     @Test
     public void testGetContentInfo() throws FileSystemException, MalformedURLException {
-        String httpsProxyHost = null;
-        int httpsProxyPort = -1;
-        final String httpsProxy = System.getenv("https_proxy");
-        if (httpsProxy != null) {
-            final URL url = new URL(httpsProxy);
-            httpsProxyHost = url.getHost();
-            httpsProxyPort = url.getPort();
-        }
-        final FileSystemOptions opts;
-        if (httpsProxyHost != null) {
-            opts = new FileSystemOptions();
-            final Http4FileSystemConfigBuilder builder = Http4FileSystemConfigBuilder.getInstance();
-            builder.setProxyHost(opts, httpsProxyHost);
-            if (httpsProxyPort >= 0) {
-                builder.setProxyPort(opts, httpsProxyPort);
-            }
-        } else {
-            opts = null;
-        }
-
         final FileSystemManager fsManager = VFS.getManager();
-        final FileObject fo = fsManager.resolveFile("http4://www.apache.org/licenses/LICENSE-2.0.txt", opts);
+        final String uri = "http4://www.apache.org/licenses/LICENSE-2.0.txt";
+        final FileObject fo = fsManager.resolveFile(uri, getOptionsWithProxy());
         final FileContent content = fo.getContent();
         Assert.assertNotNull(content);
         // Used to NPE before fix:
         content.getContentInfo();
+    }
+
+    FileSystemOptions getOptionsWithProxy() throws MalformedURLException {
+        // get proxy host and port from env var "https_proxy"
+        String proxyHost = null;
+        int proxyPort = -1;
+        final String proxyUrl = System.getenv("https_proxy");
+        if (proxyUrl != null) {
+            final URL url = new URL(proxyUrl);
+            proxyHost = url.getHost();
+            proxyPort = url.getPort();
+        }
+
+        // return null if proxy host or port invalid
+        if (proxyHost == null || proxyPort == -1) {
+            return null;
+        }
+
+        // return options with proxy
+        final Http4FileSystemConfigBuilder builder = Http4FileSystemConfigBuilder.getInstance();
+        final FileSystemOptions opts = new FileSystemOptions();
+        builder.setProxyHost(opts, proxyHost);
+        builder.setProxyPort(opts, proxyPort);
+        return opts;
     }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/test/Http5GetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/test/Http5GetContentInfoTest.java
@@ -20,11 +20,16 @@ import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.http5.Http5FileSystemConfigBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
 import junit.framework.TestCase;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Tests VFS-427 NPE on Http5FileObject.getContent().getContentInfo().
@@ -37,12 +42,37 @@ public class Http5GetContentInfoTest extends TestCase {
      * @throws FileSystemException thrown when the getContentInfo API fails.
      */
     @Test
-    public void testGetContentInfo() throws FileSystemException {
+    public void testGetContentInfo() throws FileSystemException, MalformedURLException {
         final FileSystemManager fsManager = VFS.getManager();
-        final FileObject fo = fsManager.resolveFile("http5://www.apache.org/licenses/LICENSE-2.0.txt");
+        final String uri = "http5://www.apache.org/licenses/LICENSE-2.0.txt";
+        final FileObject fo = fsManager.resolveFile(uri, getOptionsWithProxy());
         final FileContent content = fo.getContent();
         Assert.assertNotNull(content);
         // Used to NPE before fix:
         content.getContentInfo();
+    }
+
+    FileSystemOptions getOptionsWithProxy() throws MalformedURLException {
+        // get proxy host and port from env var "https_proxy"
+        String proxyHost = null;
+        int proxyPort = -1;
+        final String proxyUrl = System.getenv("https_proxy");
+        if (proxyUrl != null) {
+            final URL url = new URL(proxyUrl);
+            proxyHost = url.getHost();
+            proxyPort = url.getPort();
+        }
+
+        // return null if proxy host or port invalid
+        if (proxyHost == null || proxyPort == -1) {
+            return null;
+        }
+
+        // return options with proxy
+        final Http5FileSystemConfigBuilder builder = Http5FileSystemConfigBuilder.getInstance();
+        final FileSystemOptions opts = new FileSystemOptions();
+        builder.setProxyHost(opts, proxyHost);
+        builder.setProxyPort(opts, proxyPort);
+        return opts;
     }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5s/test/Http5sGetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5s/test/Http5sGetContentInfoTest.java
@@ -44,31 +44,36 @@ public class Http5sGetContentInfoTest extends TestCase {
      */
     @Test
     public void testGetContentInfo() throws FileSystemException, MalformedURLException {
-        String httpsProxyHost = null;
-        int httpsProxyPort = -1;
-        final String httpsProxy = System.getenv("https_proxy");
-        if (httpsProxy != null) {
-            final URL url = new URL(httpsProxy);
-            httpsProxyHost = url.getHost();
-            httpsProxyPort = url.getPort();
-        }
-        final FileSystemOptions opts;
-        if (httpsProxyHost != null) {
-            opts = new FileSystemOptions();
-            final Http5FileSystemConfigBuilder builder = Http5FileSystemConfigBuilder.getInstance();
-            builder.setProxyHost(opts, httpsProxyHost);
-            if (httpsProxyPort >= 0) {
-                builder.setProxyPort(opts, httpsProxyPort);
-            }
-        } else {
-            opts = null;
-        }
-
         final FileSystemManager fsManager = VFS.getManager();
-        final FileObject fo = fsManager.resolveFile("http5://www.apache.org/licenses/LICENSE-2.0.txt", opts);
+        final String uri = "http5://www.apache.org/licenses/LICENSE-2.0.txt";
+        final FileObject fo = fsManager.resolveFile(uri, getOptionsWithProxy());
         final FileContent content = fo.getContent();
         Assert.assertNotNull(content);
         // Used to NPE before fix:
         content.getContentInfo();
+    }
+
+    FileSystemOptions getOptionsWithProxy() throws MalformedURLException {
+        // get proxy host and port from env var "https_proxy"
+        String proxyHost = null;
+        int proxyPort = -1;
+        final String proxyUrl = System.getenv("https_proxy");
+        if (proxyUrl != null) {
+            final URL url = new URL(proxyUrl);
+            proxyHost = url.getHost();
+            proxyPort = url.getPort();
+        }
+
+        // return null if proxy host or port invalid
+        if (proxyHost == null || proxyPort == -1) {
+            return null;
+        }
+
+        // return options with proxy
+        final Http5FileSystemConfigBuilder builder = Http5FileSystemConfigBuilder.getInstance();
+        final FileSystemOptions opts = new FileSystemOptions();
+        builder.setProxyHost(opts, proxyHost);
+        builder.setProxyPort(opts, proxyPort);
+        return opts;
     }
 }


### PR DESCRIPTION
Some tests are failing because of the absence of the Http/Https proxy configure.
This is a fix for them.