### PR TITLE
VFS-781 - webdav4,http4/5 client issues

### DIFF
--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -544,13 +544,18 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
      * @return The encoded URL String.
      */
     private String hrefString(final GenericURLFileName name) {
-        final GenericURLFileName newFile = new GenericURLFileName("http", name.getHostName(), name.getPort(), name.getDefaultPort(),
+        final String scheme = getHttpScheme(name);
+        final GenericURLFileName newFile = new GenericURLFileName(scheme, name.getHostName(), name.getPort(), name.getDefaultPort(),
                 null, null, name.getPath(), name.getType(), name.getQueryString());
         try {
             return newFile.getURIEncoded(this.getUrlCharset());
         } catch (final Exception e) {
             return name.getURI();
         }
+    }
+
+    private String getHttpScheme(GenericURLFileName name) {
+        return  "webdav4s".equalsIgnoreCase(name.getScheme()) || "webdavs".equalsIgnoreCase(name.getScheme()) ? "https" : "http";
     }
 
     private boolean isCurrentFile(final String href, final GenericURLFileName fileName) {
@@ -614,7 +619,8 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             user = name.getUserName();
             password = name.getPassword();
         }
-        final GenericURLFileName newFile = new GenericURLFileName("http", name.getHostName(), name.getPort(), name.getDefaultPort(),
+        final String scheme = getHttpScheme(name);
+        final GenericURLFileName newFile = new GenericURLFileName(scheme, name.getHostName(), name.getPort(), name.getDefaultPort(),
                 user, password, name.getPath(), name.getType(), name.getQueryString());
         try {
             return newFile.getURIEncoded(this.getUrlCharset());

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
@@ -54,11 +54,16 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
@@ -174,13 +179,14 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
         final ConnectionReuseStrategy connectionReuseStrategy = builder.isKeepAlive(fileSystemOptions)
                 ? DefaultConnectionReuseStrategy.INSTANCE
                 : NoConnectionReuseStrategy.INSTANCE;
-
+        SSLContext sslContext = createSSLContext(builder, fileSystemOptions);
+        HostnameVerifier hostNameVerifier = createHostnameVerifier(builder, fileSystemOptions);
         final HttpClientBuilder httpClientBuilder =
                 HttpClients.custom()
                 .setRoutePlanner(createHttpRoutePlanner(builder, fileSystemOptions))
-                .setConnectionManager(createConnectionManager(builder, fileSystemOptions))
-                .setSSLContext(createSSLContext(builder, fileSystemOptions))
-                .setSSLHostnameVerifier(createHostnameVerifier(builder, fileSystemOptions))
+                .setConnectionManager(createConnectionManager(builder, fileSystemOptions, sslContext, hostNameVerifier))
+                .setSSLContext(sslContext)
+                .setSSLHostnameVerifier(hostNameVerifier)
                 .setConnectionReuseStrategy(connectionReuseStrategy)
                 .setDefaultRequestConfig(createDefaultRequestConfig(builder, fileSystemOptions))
                 .setDefaultHeaders(defaultHeaders)
@@ -205,6 +211,8 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
             final FileSystemOptions fileSystemOptions) throws FileSystemException {
         try {
             final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+
+            sslContextBuilder.setKeyStoreType(builder.getKeyStoreType(fileSystemOptions));
 
             File keystoreFileObject = null;
             final String keystoreFile = builder.getKeyStoreFile(fileSystemOptions);
@@ -259,7 +267,7 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                 UserAuthenticationData.PASSWORD, UserAuthenticatorUtils.toChar(rootName.getPassword())));
 
         if (username != null && !username.isEmpty()) {
-            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), AuthScope.ANY_PORT),
+            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), rootName.getPort()),
                     new UsernamePasswordCredentials(username, password));
         }
 
@@ -276,11 +284,11 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                 if (proxyAuthData != null) {
                     final UsernamePasswordCredentials proxyCreds = new UsernamePasswordCredentials(
                             UserAuthenticatorUtils.toString(
-                                    UserAuthenticatorUtils.getData(authData, UserAuthenticationData.USERNAME, null)),
+                                    UserAuthenticatorUtils.getData(proxyAuthData, UserAuthenticationData.USERNAME, null)),
                             UserAuthenticatorUtils.toString(
-                                    UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD, null)));
+                                    UserAuthenticatorUtils.getData(proxyAuthData, UserAuthenticationData.PASSWORD, null)));
 
-                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), AuthScope.ANY_PORT),
+                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
                             proxyCreds);
                 }
 
@@ -297,8 +305,16 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
     }
 
     private HttpClientConnectionManager createConnectionManager(final Http4FileSystemConfigBuilder builder,
-            final FileSystemOptions fileSystemOptions) throws FileSystemException {
-        final PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+            final FileSystemOptions fileSystemOptions, SSLContext sslContext, HostnameVerifier verifier) throws FileSystemException {
+
+        final SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(sslContext, verifier);
+        final Registry<ConnectionSocketFactory> socketFactoryRegistry =
+                RegistryBuilder.<ConnectionSocketFactory> create()
+                        .register("https", sslFactory)
+                        .register("http", new PlainConnectionSocketFactory())
+                        .build();
+
+        final PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
         connManager.setMaxTotal(builder.getMaxTotalConnections(fileSystemOptions));
         connManager.setDefaultMaxPerRoute(builder.getMaxConnectionsPerHost(fileSystemOptions));
 
@@ -335,9 +351,10 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
             final FileSystemOptions fileSystemOptions) {
         final String proxyHost = builder.getProxyHost(fileSystemOptions);
         final int proxyPort = builder.getProxyPort(fileSystemOptions);
+        final String proxyScheme = builder.getProxyScheme(fileSystemOptions);
 
         if (proxyHost != null && proxyHost.length() > 0 && proxyPort > 0) {
-            return new HttpHost(proxyHost, proxyPort);
+            return new HttpHost(proxyHost, proxyPort, proxyScheme);
         }
 
         return null;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystemConfigBuilder.java
@@ -16,10 +16,12 @@
  */
 package org.apache.commons.vfs2.provider.http4;
 
+import java.security.KeyStore;
 import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.UserAuthenticator;
+import org.apache.http.HttpHost;
 import org.apache.http.cookie.Cookie;
 
 /**
@@ -86,6 +88,11 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * </p>
      */
     private static final String KEYSTORE_PASS = "http.keystorePass";
+
+    /**
+     * Defines the keystore type for the underlying HttpClient.
+     */
+    private static final String KEYSTORE_TYPE = "http.keyStoreType";
 
     /**
      * Defines whether the host name should be verified or not in SSL connections.
@@ -228,6 +235,18 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     /**
+     * Sets the proxy-scheme to use for http connection. You have to set the ProxyHost too if you would like to have the
+     * proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @param proxyScheme the protocol scheme
+     * @see #setProxyHost
+     */
+    public void setProxyScheme(final FileSystemOptions opts, final String proxyScheme) {
+        setParam(opts, "proxyScheme", proxyScheme);
+    }
+
+    /**
      * Gets the proxy to use for http connection. You have to set the ProxyPort too if you would like to have the proxy
      * really used.
      *
@@ -249,6 +268,18 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public int getProxyPort(final FileSystemOptions opts) {
         return getInteger(opts, "proxyPort", 0);
+    }
+
+    /**
+     * Gets the proxy-scheme to use for http the connection. You have to set the ProxyHost too if you would like to have
+     * the proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @return proxyScheme: the http/https scheme of proxy server
+     * @see #setProxyHost
+     */
+    public String getProxyScheme(final FileSystemOptions opts) {
+        return getString(opts, "proxyScheme", HttpHost.DEFAULT_SCHEME_NAME);
     }
 
     /**
@@ -492,6 +523,23 @@ public class Http4FileSystemConfigBuilder extends FileSystemConfigBuilder {
         return (String) getParam(opts, KEYSTORE_PASS);
     }
 
+    /**
+     * Set keystore type for SSL connections.
+     * @param opts the file system options to modify
+     * @param keyStoreType keystore type for SSL connections
+     */
+    public void setKeyStoreType(final FileSystemOptions opts, final String keyStoreType) {
+        setParam(opts, KEYSTORE_TYPE, keyStoreType);
+    }
+
+    /**
+     * Get keystore type for SSL connections.
+     * @param opts the file system options to modify
+     * @return keystore type for SSL connections
+     */
+    public String getKeyStoreType(final FileSystemOptions opts) {
+        return getString(opts, KEYSTORE_TYPE, KeyStore.getDefaultType());
+    }
     /**
      * Sets if the hostname should be verified in SSL context.
      *

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileProvider.java
@@ -205,6 +205,7 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
             final FileSystemOptions fileSystemOptions) throws FileSystemException {
         try {
             final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+            sslContextBuilder.setKeyStoreType(builder.getKeyStoreType(fileSystemOptions));
 
             File keystoreFileObject = null;
             final String keystoreFile = builder.getKeyStoreFile(fileSystemOptions);
@@ -260,7 +261,7 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
 
         if (username != null && !username.isEmpty()) {
             // -1 for any port
-            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), -1),
+            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), rootName.getPort()),
                     new UsernamePasswordCredentials(username, password));
         }
 
@@ -277,11 +278,11 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
                 if (proxyAuthData != null) {
                     final UsernamePasswordCredentials proxyCreds = new UsernamePasswordCredentials(
                             UserAuthenticatorUtils.toString(
-                                    UserAuthenticatorUtils.getData(authData, UserAuthenticationData.USERNAME, null)),
-                            UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD, null));
+                                    UserAuthenticatorUtils.getData(proxyAuthData, UserAuthenticationData.USERNAME, null)),
+                            UserAuthenticatorUtils.getData(proxyAuthData, UserAuthenticationData.PASSWORD, null));
 
                     // -1 for any port
-                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), -1),
+                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
                             proxyCreds);
                 }
 
@@ -344,11 +345,11 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
 
     private HttpHost getProxyHttpHost(final Http5FileSystemConfigBuilder builder,
             final FileSystemOptions fileSystemOptions) {
+        final String proxyScheme = builder.getProxyScheme(fileSystemOptions);
         final String proxyHost = builder.getProxyHost(fileSystemOptions);
         final int proxyPort = builder.getProxyPort(fileSystemOptions);
-
         if (proxyHost != null && proxyHost.length() > 0 && proxyPort > 0) {
-            return new HttpHost(proxyHost, proxyPort);
+            return new HttpHost(proxyScheme, proxyHost, proxyPort);
         }
 
         return null;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileSystemConfigBuilder.java
@@ -16,11 +16,14 @@
  */
 package org.apache.commons.vfs2.provider.http5;
 
+import java.security.KeyStore;
 import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.UserAuthenticator;
 import org.apache.hc.client5.http.cookie.Cookie;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
 
 /**
  * Configuration options builder utility for http5 provider.
@@ -86,6 +89,11 @@ public class Http5FileSystemConfigBuilder extends FileSystemConfigBuilder {
      * </p>
      */
     private static final String KEYSTORE_PASS = "http.keystorePass";
+
+    /**
+     * Defines the keystore type for the underlying HttpClient.
+     */
+    private static final String KEYSTORE_TYPE = "http.keyStoreType";
 
     /**
      * Defines whether the host name should be verified or not in SSL connections.
@@ -240,6 +248,30 @@ public class Http5FileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setProxyPort(final FileSystemOptions opts, final int proxyPort) {
         setParam(opts, "proxyPort", Integer.valueOf(proxyPort));
+    }
+
+    /**
+     * Sets the proxy-scheme to use for http connection. You have to set the ProxyHost too if you would like to have the
+     * proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @param proxyScheme the protocol scheme
+     * @see #setProxyHost
+     */
+    public void setProxyScheme(final FileSystemOptions opts, final String proxyScheme) {
+        setParam(opts, "proxyScheme", proxyScheme);
+    }
+
+    /**
+     * Gets the proxy-scheme to use for http the connection. You have to set the ProxyHost too if you would like to have
+     * the proxy really used.
+     *
+     * @param opts The FileSystem options.
+     * @return proxyScheme: the http/https scheme of proxy server
+     * @see #setProxyHost
+     */
+    public String getProxyScheme(final FileSystemOptions opts) {
+        return getString(opts, "proxyScheme", URIScheme.HTTP.getId());
     }
 
     /**
@@ -505,6 +537,24 @@ public class Http5FileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     String getKeyStorePass(final FileSystemOptions opts) {
         return (String) getParam(opts, KEYSTORE_PASS);
+    }
+
+    /**
+     * Set keystore type for SSL connections.
+     * @param opts the file system options to modify
+     * @param keyStoreType keystore type for SSL connections
+     */
+    public void setKeyStoreType(final FileSystemOptions opts, final String keyStoreType) {
+        setParam(opts, KEYSTORE_TYPE, keyStoreType);
+    }
+
+    /**
+     * Get keystore type for SSL connections.
+     * @param opts the file system options to modify
+     * @return keystore type for SSL connections
+     */
+    public String getKeyStoreType(final FileSystemOptions opts) {
+        return getString(opts, KEYSTORE_TYPE, KeyStore.getDefaultType());
     }
 
     /**


### PR DESCRIPTION
This PR will fix following issues,
1. WEBDAV4 GenericURLFileName hardcoded scheme("http") won't work for https connection
2. Http4/Http5 proxy authentication details are not set correctly default user auth set to proxy auth which is wrong
3. SSL connection setting keystore type setting should be supported in config builders
4. If http host and proxy host are same with different ports that leads to conflict due to auth scope any
5. allow user to set proxy host scheme http vs https
