### PR TITLE
[VFS-785] Credentials conflicting when root and proxy hosts are same name but different ports

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileProvider.java
@@ -259,7 +259,7 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                 UserAuthenticationData.PASSWORD, UserAuthenticatorUtils.toChar(rootName.getPassword())));
 
         if (username != null && !username.isEmpty()) {
-            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), AuthScope.ANY_PORT),
+            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), rootName.getPort()),
                     new UsernamePasswordCredentials(username, password));
         }
 
@@ -280,7 +280,7 @@ public class Http4FileProvider extends AbstractOriginatingFileProvider {
                             UserAuthenticatorUtils.toString(
                                     UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD, null)));
 
-                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), AuthScope.ANY_PORT),
+                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
                             proxyCreds);
                 }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileProvider.java
@@ -259,8 +259,8 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
                 UserAuthenticationData.PASSWORD, UserAuthenticatorUtils.toChar(rootName.getPassword()));
 
         if (username != null && !username.isEmpty()) {
-            // -1 for any port
-            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), -1),
+            // set root port
+            credsProvider.setCredentials(new AuthScope(rootName.getHostName(), rootName.getPort()),
                     new UsernamePasswordCredentials(username, password));
         }
 
@@ -280,8 +280,8 @@ public class Http5FileProvider extends AbstractOriginatingFileProvider {
                                     UserAuthenticatorUtils.getData(authData, UserAuthenticationData.USERNAME, null)),
                             UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD, null));
 
-                    // -1 for any port
-                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), -1),
+                    // set proxy host port
+                    credsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
                             proxyCreds);
                 }
 


### PR DESCRIPTION
VFS-785 e.g. if URI for root is https://github.com:8443/test.txt and proxy is github.com:3128 then credentials may get overridden in credential provider map