### PR TITLE
Fix test fail caused by lack proxy configuration for machines behind a proxy

### DIFF
--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5s/test/Http5sGetContentInfoTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5s/test/Http5sGetContentInfoTest.java
@@ -105,7 +105,10 @@ public class Http5sGetContentInfoTest extends TestCase {
 
    private FileSystemOptions getOptionsWithSSL() throws MalformedURLException {
         final Http5FileSystemConfigBuilder builder = Http5FileSystemConfigBuilder.getInstance();
-        final FileSystemOptions opts = new FileSystemOptions();
+        FileSystemOptions opts = getOptionsWithProxy();
+        if (opts == null) {
+            opts = new FileSystemOptions();
+        }
         final URL serverJksResource = ClassLoader.getSystemClassLoader().getResource(SERVER_JCEKS_RES);
         builder.setKeyStoreFile(opts, serverJksResource.getFile());
         builder.setKeyStorePass(opts, "Hello_1234");


### PR DESCRIPTION
`org.apache.commons.vfs2.provider.http5s.test.Http5sGetContentInfoTest#testSSLGetContentInfo`  test fail caused by lack proxy configure. This PR is a fix for it.