### PR TITLE
Modify some calls of method Collection.toArray

### DIFF
--- a/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
+++ b/commons-vfs2-examples/src/main/java/org/apache/commons/vfs2/example/Shell.java
@@ -357,7 +357,7 @@ public final class Shell {
         while (tokens.hasMoreTokens()) {
             cmd.add(tokens.nextToken());
         }
-        return cmd.toArray(new String[cmd.size()]);
+        return cmd.toArray(new String[0]);
     }
 
     private static String getVersion(final Class<?> cls) {

--- a/commons-vfs2-jackrabbit1/src/main/java/org/apache/commons/vfs2/provider/webdav/WebdavFileObject.java
+++ b/commons-vfs2-jackrabbit1/src/main/java/org/apache/commons/vfs2/provider/webdav/WebdavFileObject.java
@@ -394,7 +394,7 @@ public class WebdavFileObject extends HttpFileObject<WebdavFileSystem> {
                         }
                     }
                 }
-                return vfs.toArray(new WebdavFileObject[vfs.size()]);
+                return vfs.toArray(new WebdavFileObject[0]);
             }
             throw new FileNotFolderException(getName());
         } catch (final FileNotFolderException fnfe) {

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -395,7 +395,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                         }
                     }
                 }
-                return vfs.toArray(new Webdav4FileObject[vfs.size()]);
+                return vfs.toArray(new Webdav4FileObject[0]);
             }
             throw new FileNotFolderException(getName());
         } catch (final FileNotFolderException fnfe) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileSystemOptions.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileSystemOptions.java
@@ -173,9 +173,8 @@ public final class FileSystemOptions implements Cloneable {
             }
         }
 
-        final Object[] array = new Object[propsSz];
-        final int hash = Arrays.deepHashCode(myOptions.values().toArray(array));
-        final int hashFk = Arrays.deepHashCode(theirOptions.values().toArray(array));
+        final int hash = Arrays.deepHashCode(myOptions.values().toArray());
+        final int hashFk = Arrays.deepHashCode(theirOptions.values().toArray());
         if (hash < hashFk) {
             return -1;
         }
@@ -198,7 +197,7 @@ public final class FileSystemOptions implements Cloneable {
                     ? (SortedMap<FileSystemOptionKey, Object>) options
                     : new TreeMap<>(options);
             result = prime * result + myOptions.keySet().hashCode();
-            result = prime * result + Arrays.deepHashCode(myOptions.values().toArray(new Object[options.size()]));
+            result = prime * result + Arrays.deepHashCode(myOptions.values().toArray());
         }
         return result;
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/WildcardFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/WildcardFileFilter.java
@@ -196,7 +196,7 @@ public class WildcardFileFilter implements FileFilter, Serializable {
             list.add(buffer.toString());
         }
 
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     // CHECKSTYLE:ON

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
@@ -369,7 +369,7 @@ public class StandardFileSystemManager extends DefaultFileSystemManager {
                 classes.add(className);
             }
         }
-        return classes.toArray(new String[classes.size()]);
+        return classes.toArray(new String[0]);
     }
 
     /**
@@ -386,7 +386,7 @@ public class StandardFileSystemManager extends DefaultFileSystemManager {
                 schemes.add(scheme);
             }
         }
-        return schemes.toArray(new String[schemes.size()]);
+        return schemes.toArray(new String[0]);
     }
 
     /**
@@ -400,7 +400,7 @@ public class StandardFileSystemManager extends DefaultFileSystemManager {
             final Element scheme = (Element) schemaElements.item(i);
             schemas.add(scheme.getAttribute("name"));
         }
-        return schemas.toArray(new String[schemas.size()]);
+        return schemas.toArray(new String[0]);
     }
 
     private ClassLoader getValidClassLoader(final Class<?> clazz) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/VFSClassLoader.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/VFSClassLoader.java
@@ -110,7 +110,7 @@ public class VFSClassLoader extends SecureClassLoader {
      * @since 2.0
      */
     public FileObject[] getFileObjects() {
-        return resources.toArray(new FileObject[resources.size()]);
+        return resources.toArray(new FileObject[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -205,8 +205,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
             } else {
                 list.add(childName);
             }
-            children = new FileName[list.size()];
-            list.toArray(children);
+            children = list.toArray(new FileName[0]);
         }
 
         // removeChildrenCache();
@@ -991,7 +990,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
     @Override
     public FileObject[] findFiles(final FileSelector selector) throws FileSystemException {
         final List<FileObject> list = this.listFiles(selector);
-        return list == null ? null : list.toArray(new FileObject[list.size()]);
+        return list == null ? null : list.toArray(new FileObject[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileSystem.java
@@ -539,7 +539,7 @@ public abstract class AbstractFileSystem extends AbstractVfsComponent implements
         synchronized (listenerMap) {
             final ArrayList<?> listeners = listenerMap.get(fileObject.getName());
             if (listeners != null) {
-                fileListeners = listeners.toArray(new FileListener[listeners.size()]);
+                fileListeners = listeners.toArray(new FileListener[0]);
             }
         }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
@@ -244,7 +244,7 @@ public final class DefaultFileContent implements FileContent {
     public String[] getAttributeNames() throws FileSystemException {
         getAttributes();
         final Set<String> names = attrs.keySet();
-        return names.toArray(new String[names.size()]);
+        return names.toArray(new String[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DelegateFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DelegateFileObject.java
@@ -191,7 +191,7 @@ public class DelegateFileObject<AFS extends AbstractFileSystem> extends Abstract
 
             return Arrays.stream(children).map(child -> child.getName().getBaseName()).toArray(String[]::new);
         }
-        return children.toArray(new String[children.size()]);
+        return children.toArray(new String[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -378,7 +378,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
             children.add(fo);
         }
 
-        return children.toArray(new FileObject[children.size()]);
+        return children.toArray(new FileObject[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileObject.java
@@ -108,7 +108,7 @@ public class TarFileObject extends AbstractFileObject<TarFileSystem> {
             throw new RuntimeException(e);
         }
 
-        return children.toArray(new String[children.size()]);
+        return children.toArray(new String[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/zip/ZipFileObject.java
@@ -110,7 +110,7 @@ public class ZipFileObject extends AbstractFileObject<ZipFileSystem> {
             throw new RuntimeException(e);
         }
 
-        return children.toArray(new String[children.size()]);
+        return children.toArray(new String[0]);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/Os.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/Os.java
@@ -247,7 +247,7 @@ public final class Os {
                 }
             }
         }
-        return allFamilies.toArray(new OsFamily[allFamilies.size()]);
+        return allFamilies.toArray(new OsFamily[0]);
     }
 
     private static OsFamily determineOsFamily() {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/AbstractTestSuite.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/test/AbstractTestSuite.java
@@ -303,9 +303,7 @@ public abstract class AbstractTestSuite extends TestSetup {
             diff.add(element);
         }
 
-        final Thread ret[] = new Thread[diff.size()];
-        diff.toArray(ret);
-        return ret;
+        return diff.toArray(new Thread[0]);
     }
 
     private Thread[] createThreadSnapshot() {


### PR DESCRIPTION
Use method with empty array instead of pre size array.
Because it's more safe and faster.

See also this [blog](https://shipilev.net/blog/2016/arrays-wisdom-ancients/)