### PR TITLE
Rework SoftRefFilesCache locking

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -237,10 +237,10 @@ public class SoftRefFilesCache extends AbstractFilesCache {
 
     @Override
     public void close() {
-        endThread();
-
         lock.lock();
         try {
+            endThread();
+
             fileSystemCache.clear();
 
             refReverseMap.clear();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -96,21 +96,27 @@ public class SoftRefFilesCache extends AbstractFilesCache {
             return;
         }
 
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (softRefReleaseThread == null) {
                 softRefReleaseThread = new SoftRefReleaseThread();
                 softRefReleaseThread.start();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     private void endThread() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             final SoftRefReleaseThread thread = softRefReleaseThread;
             softRefReleaseThread = null;
             if (thread != null) {
                 thread.interrupt();
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -263,7 +263,13 @@ public class SoftRefFilesCache extends AbstractFilesCache {
     @Override
     public void removeFile(final FileSystem fileSystem, final FileName fileName) {
         if (removeFile(new FileSystemAndNameKey(fileSystem, fileName))) {
-            close(fileSystem);
+            lock.lock();
+
+            try {
+                close(fileSystem);
+            } finally {
+                lock.unlock();
+            }
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -43,8 +43,6 @@ import org.apache.commons.vfs2.util.Messages;
  */
 public class SoftRefFilesCache extends AbstractFilesCache {
 
-    private static final int TIMEOUT = 1000;
-
     private static final Log log = LogFactory.getLog(SoftRefFilesCache.class);
 
     private final ConcurrentMap<FileSystem, Map<FileName, Reference<FileObject>>> fileSystemCache = new ConcurrentHashMap<>();
@@ -71,7 +69,7 @@ public class SoftRefFilesCache extends AbstractFilesCache {
         public void run() {
             try {
                 while (!requestEnd) {
-                    final Reference<?> ref = refQueue.remove(TIMEOUT);
+                    final Reference<?> ref = refQueue.remove(0);
                     if (ref == null) {
                         continue;
                     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -88,28 +88,24 @@ public class SoftRefFilesCache extends AbstractFilesCache {
     public SoftRefFilesCache() {
     }
 
+    /**
+     * Called while the lock is held
+     */
     private void startThread() {
-        lock.lock();
-        try {
-            if (softRefReleaseThread == null) {
-                softRefReleaseThread = new SoftRefReleaseThread();
-                softRefReleaseThread.start();
-            }
-        } finally {
-            lock.unlock();
+        if (softRefReleaseThread == null) {
+            softRefReleaseThread = new SoftRefReleaseThread();
+            softRefReleaseThread.start();
         }
     }
 
+    /**
+     * Called while the lock is held
+     */
     private void endThread() {
-        lock.lock();
-        try {
-            final SoftRefReleaseThread thread = softRefReleaseThread;
-            softRefReleaseThread = null;
-            if (thread != null) {
-                thread.interrupt();
-            }
-        } finally {
-            lock.unlock();
+        final SoftRefReleaseThread thread = softRefReleaseThread;
+        softRefReleaseThread = null;
+        if (thread != null) {
+            thread.interrupt();
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -46,7 +46,7 @@ public class SoftRefFilesCache extends AbstractFilesCache {
     private final Map<Reference<FileObject>, FileSystemAndNameKey> refReverseMap = new HashMap<>(100);
     private final ReferenceQueue<FileObject> refQueue = new ReferenceQueue<>();
 
-    private volatile SoftRefReleaseThread softRefReleaseThread; // @GuardedBy("lock")
+    private SoftRefReleaseThread softRefReleaseThread; // @GuardedBy("lock")
 
     private final Lock lock = new ReentrantLock();
 
@@ -89,11 +89,6 @@ public class SoftRefFilesCache extends AbstractFilesCache {
     }
 
     private void startThread() {
-        // Double Checked Locking is allowed when volatile
-        if (softRefReleaseThread != null) {
-            return;
-        }
-
         lock.lock();
         try {
             if (softRefReleaseThread == null) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -71,11 +71,7 @@ public class SoftRefFilesCache extends AbstractFilesCache {
 
                     lock.lock();
                     try {
-                        final FileSystemAndNameKey key = refReverseMap.get(ref);
-
-                        if (key != null && removeFile(key)) {
-                            close(key.getFileSystem());
-                        }
+                        removeFile(ref);
                     } finally {
                         lock.unlock();
                     }
@@ -273,6 +269,17 @@ public class SoftRefFilesCache extends AbstractFilesCache {
         }
 
         return files.isEmpty();
+    }
+
+    /**
+     * Called while the lock is held
+     */
+    private void removeFile(final Reference<?> ref) {
+        final FileSystemAndNameKey key = refReverseMap.get(ref);
+
+        if (key != null && removeFile(key)) {
+            close(key.getFileSystem());
+        }
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -126,13 +126,13 @@ public class SoftRefFilesCache extends AbstractFilesCache {
             log.debug("putFile: " + this.getSafeName(fileObject));
         }
 
-        final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileObject.getFileSystem());
-
-        final Reference<FileObject> ref = createReference(fileObject, refQueue);
-        final FileSystemAndNameKey key = new FileSystemAndNameKey(fileObject.getFileSystem(), fileObject.getName());
-
         lock.lock();
         try {
+            final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileObject.getFileSystem());
+
+            final Reference<FileObject> ref = createReference(fileObject, refQueue);
+            final FileSystemAndNameKey key = new FileSystemAndNameKey(fileObject.getFileSystem(), fileObject.getName());
+
             final Reference<FileObject> old = files.put(fileObject.getName(), ref);
             if (old != null) {
                 refReverseMap.remove(old);
@@ -157,13 +157,13 @@ public class SoftRefFilesCache extends AbstractFilesCache {
             log.debug("putFile: " + this.getSafeName(fileObject));
         }
 
-        final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileObject.getFileSystem());
-
-        final Reference<FileObject> ref = createReference(fileObject, refQueue);
-        final FileSystemAndNameKey key = new FileSystemAndNameKey(fileObject.getFileSystem(), fileObject.getName());
-
         lock.lock();
         try {
+            final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileObject.getFileSystem());
+
+            final Reference<FileObject> ref = createReference(fileObject, refQueue);
+            final FileSystemAndNameKey key = new FileSystemAndNameKey(fileObject.getFileSystem(), fileObject.getName());
+
             if (files.containsKey(fileObject.getName()) && files.get(fileObject.getName()).get() != null) {
                 return false;
             }
@@ -184,10 +184,10 @@ public class SoftRefFilesCache extends AbstractFilesCache {
 
     @Override
     public FileObject getFile(final FileSystem fileSystem, final FileName fileName) {
-        final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileSystem);
-
         lock.lock();
         try {
+            final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileSystem);
+
             final Reference<FileObject> ref = files.get(fileName);
             if (ref == null) {
                 return null;
@@ -205,10 +205,10 @@ public class SoftRefFilesCache extends AbstractFilesCache {
 
     @Override
     public void clear(final FileSystem fileSystem) {
-        final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileSystem);
-
         lock.lock();
         try {
+            final Map<FileName, Reference<FileObject>> files = getOrCreateFilesystemCache(fileSystem);
+
             final Iterator<FileSystemAndNameKey> iterKeys = refReverseMap.values().iterator();
             while (iterKeys.hasNext()) {
                 final FileSystemAndNameKey key = iterKeys.next();
@@ -240,10 +240,6 @@ public class SoftRefFilesCache extends AbstractFilesCache {
         if (fileSystemCache.isEmpty()) {
             endThread();
         }
-        /*
-         * This is not thread-safe as another thread might be opening the file system ((DefaultFileSystemManager)
-         * getContext().getFileSystemManager()).closeFileSystem(fileSystem);
-         */
     }
 
     @Override
@@ -290,6 +286,9 @@ public class SoftRefFilesCache extends AbstractFilesCache {
         return files.isEmpty();
     }
 
+    /**
+     * Called while the lock is held
+     */
     protected Map<FileName, Reference<FileObject>> getOrCreateFilesystemCache(final FileSystem fileSystem) {
         if (fileSystemCache.isEmpty()) {
             startThread();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/cache/SoftRefFilesCache.java
@@ -22,8 +22,6 @@ import java.lang.ref.SoftReference;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -44,7 +42,7 @@ public class SoftRefFilesCache extends AbstractFilesCache {
 
     private static final Log log = LogFactory.getLog(SoftRefFilesCache.class);
 
-    private final ConcurrentMap<FileSystem, Map<FileName, Reference<FileObject>>> fileSystemCache = new ConcurrentHashMap<>();
+    private final Map<FileSystem, Map<FileName, Reference<FileObject>>> fileSystemCache = new HashMap<>();
     private final Map<Reference<FileObject>, FileSystemAndNameKey> refReverseMap = new HashMap<>(100);
     private final ReferenceQueue<FileObject> refQueue = new ReferenceQueue<>();
 
@@ -294,15 +292,11 @@ public class SoftRefFilesCache extends AbstractFilesCache {
             startThread();
         }
 
-        Map<FileName, Reference<FileObject>> files;
-
-        do {
-            files = fileSystemCache.get(fileSystem);
-            if (files != null) {
-                break;
-            }
+        Map<FileName, Reference<FileObject>> files = fileSystemCache.get(fileSystem);
+        if (files == null) {
             files = new HashMap<>();
-        } while (fileSystemCache.putIfAbsent(fileSystem, files) == null);
+            fileSystemCache.put(fileSystem, files);
+        }
 
         return files;
     }


### PR DESCRIPTION
This PR contains several commits which fix bugs in the SoftRefFilesCache locking code. There are quire a few race conditions and locking bugs. Additionally, it refactors the thread synchronization code to be easier, more robust and faster.