### PR TITLE
FileContentThreadData: lazy ArrayList initialization to save memory

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
@@ -442,7 +442,7 @@ public final class DefaultFileContent implements FileContent {
             final FileContentThreadData threadData = getFileContentThreadData();
 
             // Close the input stream
-            while (threadData.getInstrsSize() > 0) {
+            while (threadData.hasInputStream()) {
                 final InputStream inputStream = threadData.removeInputStream(0);
                 try {
                     if (inputStream instanceof FileContentInputStream) {
@@ -459,7 +459,7 @@ public final class DefaultFileContent implements FileContent {
             }
 
             // Close the randomAccess stream
-            while (threadData.getRastrsSize() > 0) {
+            while (threadData.hasRandomAccessContent()) {
                 final FileRandomAccessContent randomAccessContent = (FileRandomAccessContent) threadData
                         .removeRastr(0);
                 try {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
@@ -58,8 +58,8 @@ class FileContentThreadData {
         this.randomAccessContentList.add(randomAccessContent);
     }
 
-    int getInstrsSize() {
-        return this.inputStreamList.size();
+    boolean hasInputStream() {
+        return !this.inputStreamList.isEmpty();
     }
 
     public Object removeInstr(final int pos) {
@@ -91,7 +91,7 @@ class FileContentThreadData {
         outputStream = null;
     }
 
-    int getRastrsSize() {
-        return randomAccessContentList.size();
+    boolean hasRandomAccessContent() {
+        return !randomAccessContentList.isEmpty();
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
@@ -83,7 +83,7 @@ class FileContentThreadData {
     }
 
     public boolean hasStreams() {
-        return !inputStreamList.isEmpty() || outputStream != null || !randomAccessContentList.isEmpty();
+        return hasInputStream() || outputStream != null || hasRandomAccessContent();
     }
 
     public void closeOutstr() throws FileSystemException {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
@@ -29,8 +29,8 @@ class FileContentThreadData {
 
     // private int state = DefaultFileContent.STATE_CLOSED;
 
-    private final ArrayList<InputStream> inputStreamList = new ArrayList<>();
-    private final ArrayList<RandomAccessContent> randomAccessContentList = new ArrayList<>();
+    private ArrayList<InputStream> inputStreamList;
+    private ArrayList<RandomAccessContent> randomAccessContentList;
     private DefaultFileContent.FileContentOutputStream outputStream;
 
     FileContentThreadData() {
@@ -43,6 +43,8 @@ class FileContentThreadData {
      */
 
     void addInstr(final InputStream inputStream) {
+        if (this.inputStreamList == null)
+            this.inputStreamList = new ArrayList<>();
         this.inputStreamList.add(inputStream);
     }
 
@@ -55,11 +57,13 @@ class FileContentThreadData {
     }
 
     void addRastr(final RandomAccessContent randomAccessContent) {
+        if (this.randomAccessContentList == null)
+            this.randomAccessContentList = new ArrayList<>();
         this.randomAccessContentList.add(randomAccessContent);
     }
 
     boolean hasInputStream() {
-        return !this.inputStreamList.isEmpty();
+        return this.inputStreamList != null && !this.inputStreamList.isEmpty();
     }
 
     public Object removeInstr(final int pos) {
@@ -92,6 +96,6 @@ class FileContentThreadData {
     }
 
     boolean hasRandomAccessContent() {
-        return !randomAccessContentList.isEmpty();
+        return randomAccessContentList != null && !randomAccessContentList.isEmpty();
     }
 }


### PR DESCRIPTION
Don't create ArrayList instances that are never used.