### PR TITLE
Avoid File Stream

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
@@ -104,7 +105,7 @@ public class LocalFile extends AbstractFileObject<LocalFileSystem> {
      */
     @Override
     protected InputStream doGetInputStream(final int bufferSize) throws Exception {
-        return new FileInputStream(file);
+        return Files.newInputStream(file.toPath());
     }
 
     /**
@@ -126,7 +127,7 @@ public class LocalFile extends AbstractFileObject<LocalFileSystem> {
      */
     @Override
     protected OutputStream doGetOutputStream(final boolean bAppend) throws Exception {
-        return new FileOutputStream(file.getPath(), bAppend);
+        return Files.newOutputStream(file.toPath(),  bAppend ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -95,10 +94,10 @@ public class TarFileSystem extends AbstractFileSystem {
     protected TarArchiveInputStream createTarFile(final File file) throws FileSystemException {
         try {
             if ("tgz".equalsIgnoreCase(getRootName().getScheme())) {
-                return new TarArchiveInputStream(new GZIPInputStream(Files.newInputStream(file.toPath())));
+                return new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
             } else if ("tbz2".equalsIgnoreCase(getRootName().getScheme())) {
                 return new TarArchiveInputStream(
-                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), Files.newInputStream(file.toPath())));
+                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), new FileInputStream(file)));
             }
             return new TarArchiveInputStream(new FileInputStream(file));
         } catch (final IOException ioe) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,10 +95,10 @@ public class TarFileSystem extends AbstractFileSystem {
     protected TarArchiveInputStream createTarFile(final File file) throws FileSystemException {
         try {
             if ("tgz".equalsIgnoreCase(getRootName().getScheme())) {
-                return new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
+                return new TarArchiveInputStream(new GZIPInputStream(Files.newInputStream(file.toPath())));
             } else if ("tbz2".equalsIgnoreCase(getRootName().getScheme())) {
                 return new TarArchiveInputStream(
-                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), new FileInputStream(file)));
+                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), Files.newInputStream(file.toPath())));
             }
             return new TarArchiveInputStream(new FileInputStream(file));
         } catch (final IOException ioe) {


### PR DESCRIPTION
Use Files.newOutputStream instead of new FileOutputStream (fileName).
Use Files.newInputStream instead of new  FileInputStream  (fileName)