### PR TITLE
Set `instance` to `null` after closing it

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/VFS.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/VFS.java
@@ -40,6 +40,7 @@ public final class VFS {
     public static synchronized void close() {
         if (instance != null) {
             instance.close();
+            instance = null;
         }
     }
 


### PR DESCRIPTION
[According to the documentation](https://github.com/apache/commons-vfs/blob/rel/commons-vfs-2.8.0/commons-vfs2/src/main/java/org/apache/commons/vfs2/VFS.java#L35), after `VFS.close` is called, calling `getManager` will create a new instance. That won't happen unless the instance is set to `null` first.