### PR TITLE
Replace construction of FileInputStream and FileOutputStream objects with Files NIO APIs.

### DIFF
--- a/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/test/WebdavProviderTestCase.java
+++ b/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/test/WebdavProviderTestCase.java
@@ -17,9 +17,9 @@
 package org.apache.commons.vfs2.provider.webdav.test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -172,7 +172,7 @@ public class WebdavProviderTestCase extends AbstractProviderTestConfig {
         final File[] files = sourceDir.listFiles();
         for (final File file : files) {
             if (file.isFile()) {
-                try (InputStream data = new FileInputStream(file)) {
+                try (InputStream data = Files.newInputStream(file.toPath())) {
                     message("Importing file " + file);
                     JcrUtils.putFile(parent, file.getName(), "application/octet-stream", data);
                 }

--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/Webdav4ProviderTestCase.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/Webdav4ProviderTestCase.java
@@ -17,9 +17,9 @@
 package org.apache.commons.vfs2.provider.webdav4.test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -173,7 +173,7 @@ public class Webdav4ProviderTestCase extends AbstractProviderTestConfig {
         final File[] files = sourceDir.listFiles();
         for (final File file : files) {
             if (file.isFile()) {
-                try (final InputStream data = new FileInputStream(file)) {
+                try (final InputStream data = Files.newInputStream(file.toPath())) {
                     message("Importing file " + file);
                     JcrUtils.putFile(parent, file.getName(), "application/octet-stream", data);
                 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFile.java
@@ -18,11 +18,11 @@ package org.apache.commons.vfs2.provider.local;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
@@ -126,7 +126,7 @@ public class LocalFile extends AbstractFileObject<LocalFileSystem> {
      */
     @Override
     protected OutputStream doGetOutputStream(final boolean bAppend) throws Exception {
-        return new FileOutputStream(file.getPath(), bAppend);
+        return Files.newOutputStream(file.toPath(),  bAppend ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,13 +95,13 @@ public class TarFileSystem extends AbstractFileSystem {
     protected TarArchiveInputStream createTarFile(final File file) throws FileSystemException {
         try {
             if ("tgz".equalsIgnoreCase(getRootName().getScheme())) {
-                return new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
+                return new TarArchiveInputStream(new GZIPInputStream(Files.newInputStream(file.toPath())));
             }
             if ("tbz2".equalsIgnoreCase(getRootName().getScheme())) {
                 return new TarArchiveInputStream(
-                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), new FileInputStream(file)));
+                    Bzip2FileObject.wrapInputStream(file.getAbsolutePath(), Files.newInputStream(file.toPath())));
             }
-            return new TarArchiveInputStream(new FileInputStream(file));
+            return new TarArchiveInputStream(Files.newInputStream(file.toPath()));
         } catch (final IOException ioe) {
             throw new FileSystemException("vfs.provider.tar/open-tar-file.error", file, ioe);
         }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/BaseFilterTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/filter/BaseFilterTest.java
@@ -22,10 +22,9 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -180,7 +179,7 @@ public abstract class BaseFilterTest {
             throws IOException {
 
         final byte[] buf = new byte[1024];
-        try (final InputStream in = new BufferedInputStream(new FileInputStream(srcFile))) {
+        try (final InputStream in = new BufferedInputStream(Files.newInputStream(srcFile.toPath()))) {
             final ZipEntry zipEntry = new ZipEntry(concatPathAndFilename(destPath, srcFile.getName(), File.separator));
             zipEntry.setTime(srcFile.lastModified());
             out.putNextEntry(zipEntry);
@@ -248,7 +247,7 @@ public abstract class BaseFilterTest {
             throw new IllegalArgumentException("destFile cannot be null");
         }
 
-        try (final ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(destFile)))) {
+        try (final ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(destFile.toPath())))) {
             zipDir(srcDir, filter, destPath, out);
         }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileMonitorTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileMonitorTest.java
@@ -20,9 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.AbstractVfsTestCase;
@@ -325,7 +327,7 @@ public class DefaultFileMonitorTest {
 
     private void writeToFile(final File file) throws IOException {
         // assertTrue(file.delete());
-        try (final FileWriter out = new FileWriter(file)) {
+        try (final BufferedWriter out = Files.newBufferedWriter(file.toPath())) {
             out.write("string=value1");
         }
     }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/ConversionTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/ConversionTestCase.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
@@ -59,7 +59,7 @@ public class ConversionTestCase {
         assertEquals(file.getAbsoluteFile(), new File(file.toURI().getPath()));
         assertEquals(file.getAbsoluteFile(), new File(new URL(fileURL).toURI().getPath()));
         try {
-            new FileOutputStream(file).close();
+            Files.newOutputStream(file.toPath()).close();
             assertTrue(file.exists());
 
             final FileSystemManager manager = VFS.getManager();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/LargeTarTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/LargeTarTestCase.java
@@ -21,10 +21,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
@@ -175,8 +175,9 @@ public class LargeTarTestCase {
             };
             source.start();
 
+            final File gzFile = new File(path + name + ".tar.gz");
             // Create compressed archive
-            final OutputStream outGzipFileStream = new FileOutputStream(path + name + ".tar.gz");
+            final OutputStream outGzipFileStream = Files.newOutputStream(gzFile.toPath());
 
             final GzipCompressorOutputStream outGzipStream = (GzipCompressorOutputStream) new CompressorStreamFactory()
                     .createCompressorOutputStream(CompressorStreamFactory.GZIP, outGzipFileStream);


### PR DESCRIPTION
Use Files.newOutputStream instead of new FileOutputStream (fileName).
Use Files.newInputStream instead of new FileInputStream (fileName)