### PR TITLE
Fix closing the files cache after warning that not all components have been closed

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -555,6 +555,9 @@ public class DefaultFileSystemManager implements FileSystemManager {
         // collections with add()
         typeMap.clear();
 
+        // Close cache last.
+        closeComponent(filesCache);
+
         // should not happen, but make debugging easier:
         if (!components.isEmpty()) {
             log.warn("DefaultFilesystemManager.close: not all components are closed: " + components.toString());
@@ -566,11 +569,6 @@ public class DefaultFileSystemManager implements FileSystemManager {
 
         // virtual schemas
         virtualFileSystemSchemes.clear();
-
-        // Close cache last.
-        if (filesCache != null) {
-            filesCache.close();
-        }
 
         // setters and derived state
         defaultProvider = null;


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/VFS-796.