### PR TITLE
Remove usage of `ThreadLocal` in `DefaultFileContent`

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java
@@ -570,10 +570,8 @@ public final class DefaultFileContent implements FileContent {
     private void endInput(final InputStream instr) {
         synchronized (this) {
             final FileContentThreadData fileContentThreadData = getFileContentThreadData();
-            if (fileContentThreadData != null) {
-                fileContentThreadData.remove(instr);
-            }
-            if (fileContentThreadData == null || !fileContentThreadData.hasStreams()) {
+            fileContentThreadData.remove(instr);
+            if (!fileContentThreadData.hasStreams()) {
                 // remove even when no value is set to remove key
                 this.fileContentThreadData = null;
             }
@@ -587,10 +585,8 @@ public final class DefaultFileContent implements FileContent {
     private void endRandomAccess(final RandomAccessContent rac) {
         synchronized (this) {
             final FileContentThreadData fileContentThreadData = getFileContentThreadData();
-            if (fileContentThreadData != null) {
-                fileContentThreadData.remove(rac);
-            }
-            if (fileContentThreadData == null || !fileContentThreadData.hasStreams()) {
+            fileContentThreadData.remove(rac);
+            if (!fileContentThreadData.hasStreams()) {
                 // remove even when no value is set to remove key
                 this.fileContentThreadData = null;
             }
@@ -604,10 +600,8 @@ public final class DefaultFileContent implements FileContent {
     private void endOutput() throws Exception {
         synchronized (this) {
             final FileContentThreadData fileContentThreadData = getFileContentThreadData();
-            if (fileContentThreadData != null) {
-                fileContentThreadData.setOutputStream(null);
-            }
-            if (fileContentThreadData == null || !fileContentThreadData.hasStreams()) {
+            fileContentThreadData.setOutputStream(null);
+            if (!fileContentThreadData.hasStreams()) {
                 // remove even when no value is set to remove key
                 this.fileContentThreadData = null;
             }
@@ -623,8 +617,7 @@ public final class DefaultFileContent implements FileContent {
      */
     @Override
     public synchronized boolean isOpen() {
-        final FileContentThreadData fileContentThreadData = getFileContentThreadData();
-        if (fileContentThreadData != null && fileContentThreadData.hasStreams()) {
+        if (getFileContentThreadData().hasStreams()) {
             return true;
         }
         // getFileContentThreadData() created empty entry

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/FileContentThreadData.java
@@ -23,7 +23,7 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.RandomAccessContent;
 
 /**
- * Holds the data which needs to be local to the current thread
+ * Holds information about the opened streams of a file (from any thread)
  */
 class FileContentThreadData {
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpMultiThreadWriteTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpMultiThreadWriteTests.java
@@ -80,6 +80,8 @@ public class SftpMultiThreadWriteTests extends AbstractProviderTestCase {
                     assertFalse(fileCopy.exists());
                     fileCopy.copyFrom(localFileObject, Selectors.SELECT_SELF);
                 } catch (final Throwable e) {
+                    System.err.println("Copying threw an exception:");
+                    e.printStackTrace(System.err);
                     return false;
                 }
                 return true;
@@ -93,6 +95,8 @@ public class SftpMultiThreadWriteTests extends AbstractProviderTestCase {
                 try {
                     return fut.get(5, TimeUnit.SECONDS);
                 } catch (final Exception e) {
+                    System.err.println("Waiting for promise threw an exception:");
+                    e.printStackTrace(System.err);
                     return false;
                 }
             }));


### PR DESCRIPTION
This also fixes inability to close a stream from a different thread than the one that opened it. See discussion in https://github.com/apache/commons-vfs/pull/155.

I tried to mimic pretty much exactly the code before (to minimize the changes) but to fix the underlying issue. There are still problems like concurrently closing one stream (which potentially does `this.fileContentThreadData = null` if it was the last stream) and opening a new one (which might add a stream to the existing `this.fileContentThreadData`, causing it to be "lost" because of the setting of the variable to `null` during the closing) but 1) they were also there before; 2) they will be very rare and 3) should be the subject of a later PR.

cc @garydgregory, @MaxKellermann