### PR TITLE
VFS-801 - Redundant local variable

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/auth/StaticUserAuthenticator.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/auth/StaticUserAuthenticator.java
@@ -125,8 +125,7 @@ public class StaticUserAuthenticator implements UserAuthenticator, Comparable<St
                 return 1;
             }
 
-            final int result = thisString.compareTo(otherString);
-            return result;
+            return thisString.compareTo(otherString);
         }
         if (otherString != null) {
             return -1;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -436,9 +436,8 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
             final boolean ok;
             final FtpClient ftpClient = getAbstractFileSystem().getClient();
             try {
-                final String oldName = relPath;
                 final String newName = ((FtpFileObject) FileObjectUtils.getAbstractFileObject(newFile)).getRelPath();
-                ok = ftpClient.rename(oldName, newName);
+                ok = ftpClient.rename(relPath, newName);
             } finally {
                 getAbstractFileSystem().putClient(ftpClient);
             }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/jar/JarFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/jar/JarFileSystem.java
@@ -94,8 +94,7 @@ public class JarFileSystem extends ZipFileSystem {
     Object getAttribute(final Name attrName) throws FileSystemException {
         try {
             final Attributes attr = getAttributes();
-            final String value = attr.getValue(attrName);
-            return value;
+            return attr.getValue(attrName);
         } catch (final IOException ioe) {
             throw new FileSystemException(attrName.toString(), ioe);
         }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/tar/TarFileSystem.java
@@ -220,8 +220,7 @@ public class TarFileSystem extends AbstractFileSystem {
             }
             tarFile = null;
         }
-        final TarArchiveInputStream tarFile = createTarFile(this.file);
-        this.tarFile = tarFile;
+        this.tarFile = createTarFile(this.file);
     }
 
     /**


### PR DESCRIPTION
Reports unnecessary local variables, which add nothing to the comprehensibility of a method.
