### PR TITLE
VFS-805 - HTTP seek always exhausts response

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/MonitoredHttpResponseContentInputStream.java
@@ -39,6 +39,17 @@ final class MonitoredHttpResponseContentInputStream extends MonitorInputStream {
         this.httpResponse = httpResponse;
     }
 
+    /**
+     * Prevent closing the stream itself if the httpResponse is closeable.
+     * Closing the stream may consume all remaining data no matter how large (VFS-805).
+     */
+    @Override
+    protected void closeSuper() throws IOException {
+        if (!(httpResponse instanceof CloseableHttpResponse)) {
+            super.closeSuper();
+        }
+    }
+
     @Override
     protected void onClose() throws IOException {
         if (httpResponse instanceof CloseableHttpResponse) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/MonitoredHttpResponseContentInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/MonitoredHttpResponseContentInputStream.java
@@ -38,6 +38,15 @@ final class MonitoredHttpResponseContentInputStream extends MonitorInputStream {
         this.httpResponse = httpResponse;
     }
 
+    /**
+     * Prevent closing the stream itself if the httpResponse is closeable.
+     * Closing the stream may consume all remaining data no matter how large (VFS-805).
+     */
+    @Override
+    protected void closeSuper() throws IOException {
+        // Suppressed close() invocation on the underlying input stream
+    }
+
     @Override
     protected void onClose() throws IOException {
         httpResponse.close();

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/MonitorInputStream.java
@@ -82,7 +82,7 @@ public class MonitorInputStream extends BufferedInputStream {
         // Close the stream
         IOException exc = null;
         try {
-            super.close();
+            closeSuper();
         } catch (final IOException ioe) {
             exc = ioe;
         }
@@ -106,6 +106,16 @@ public class MonitorInputStream extends BufferedInputStream {
      */
     public long getCount() {
         return atomicCount.get();
+    }
+
+    /**
+     * This method exists in order to allow overriding whether to actually close
+     * the underlying stream (VFS-805). There are cases where closing that stream will
+     * consume any amount of remaining data. In such cases closing a different
+     * entity instead (such as an HttpResponse) may be more appropriate.
+     */
+    protected void closeSuper() throws IOException {
+        super.close();
     }
 
     /**


### PR DESCRIPTION
[Link to VFS-805 on Jira](https://issues.apache.org/jira/browse/VFS-805)

This PR affects the http4 and http5 URI schemes. The http3 scheme is unaffected because it does not use the `MonitoredHttpResponseContentInputStream` abstraction.

With this PR, closing a `MonitoredHttpResponseContentInputStream` no longer closes the underlying stream which may download *all* remaining data. The HttpResponse itself is still closed of course.

The `http5.MonitoredHttpResponseContentInputStream` variant in addition required replacing the http entity with a dummy one during close in order to prevent downloading all remaining data: In contrast to hc4, closing the http response with hc5 now also closes the entity. Interestingly, replacing the entity is possible and does not close an existing one. Not sure about how stable this behavior is, but I couldn't find any reasonable alternative. For example, `CloseableHttpResponse` has a package private constructor, so it's not possible to create a custom http response interceptor that creates an instance of a custom subclass of `CloseableHttpResponse` that doesn't close the entity.

Also, I am not sure about how to best provide a test case:
* While I see that the unit tests spawn an http server, I am not sure how much effort it would be in order for that server to *track statistics* about how much content was retrieved.
* HttpClient 3/4/5 all return that ContentLengthInputStream if the HTTP header includes a `Content-Length` entry - this part is pretty much hard coded in all version of hc. So there doesn't seem to be a simple way to inject a custom InputStream implementation that tracks how much data is being read.

Locally, I tested this change with the benchmark described in the Jira issue and let it perform 100k iterations of seeking over a 2gb file in order to potentially reveal connection leaks. For me its working.

Test cases run in the course of `mvn -Drat.skip=true clean install` were also green.