### PR TITLE
fix the sftp channel don't return to the pool when exception on  SftpFileObject.doGetOutputStream

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -217,7 +217,15 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
          */
 
         final ChannelSftp channel = getAbstractFileSystem().getChannel();
-        return new SftpOutputStream(channel, channel.put(relPath, bAppend ? ChannelSftp.APPEND : ChannelSftp.OVERWRITE));
+        try {
+            return new SftpOutputStream(channel, channel.put(relPath, bAppend ? ChannelSftp.APPEND : ChannelSftp.OVERWRITE));
+        } catch (Exception ex) {
+            // when channel.put throw exception eg. com.jcraft.jsch.SftpException: Permission denied
+            //   returns the channel to the pool
+            getAbstractFileSystem().putChannel(channel);
+            throw ex;
+        }
+
     }
 
     @Override

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/AbstractSftpProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/AbstractSftpProviderTestCase.java
@@ -420,7 +420,7 @@ abstract class AbstractSftpProviderTestCase extends AbstractProviderTestConfig {
 
     protected static String ConnectionUri;
 
-    private static SshServer Server;
+    protected static SshServer Server;
 
     private static final String TEST_URI = "test.sftp.uri";
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpPermissionExceptionTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpPermissionExceptionTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.sftp;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.apache.commons.vfs2.AbstractVfsTestCase;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test SftpFileObject.doGetOutputStream return the channel to pool, even throw a sftp write permission exception.
+ */
+public class SftpPermissionExceptionTestCase extends AbstractSftpProviderTestCase {
+
+    /**
+     * Sets up a scratch folder for the test to use.
+     */
+    protected FileObject createScratchFolder() throws Exception {
+        final FileObject scratchFolder = getWriteFolder();
+
+        // Make sure the test folder is empty
+        scratchFolder.delete(Selectors.EXCLUDE_SELF);
+        scratchFolder.createFolder();
+        scratchFolder.setWritable(false, false);
+        return scratchFolder;
+    }
+
+    /**
+     * Returns the capabilities required by the tests of this test case.
+     */
+    @Override
+    protected Capability[] getRequiredCapabilities() {
+        return new Capability[] {Capability.CREATE, Capability.DELETE, Capability.GET_TYPE, Capability.LIST_CHILDREN,
+            Capability.READ_CONTENT, Capability.WRITE_CONTENT};
+    }
+
+
+    /**
+     * Test SftpFileObject.doGetOutputStream return the channel to pool, when there is a exception in channel.put .
+     */
+    @Test
+    public void testGetOutputStreamException() throws Exception {
+        final File localFile = new File("src/test/resources/test-data/test.zip");
+
+        final FileObject localFileObject = VFS.getManager().toFileObject(localFile);
+
+        final FileObject scratchFolder = createScratchFolder();
+
+
+        // try to create local file
+        String fileName = "filecopy.txt";
+        FileObject fileObjectCopy = scratchFolder.resolveFile(fileName);
+        fileObjectCopy.setWritable(false, false);
+        fileObjectCopy.copyFrom(localFileObject, Selectors.SELECT_SELF);
+
+        // try to set the local file to readonly
+        Paths.get(AbstractVfsTestCase.getTestDirectory(),scratchFolder.getName().getBaseName(), fileName).toFile().setWritable(false);
+        for (int i = 0; i < 30; i++) {
+            try{
+                fileObjectCopy = scratchFolder.resolveFile(fileName);
+                Assert.assertFalse(fileObjectCopy.isWriteable());
+                fileObjectCopy.copyFrom(localFileObject, Selectors.SELECT_SELF);
+                Assert.fail("permission fail");
+            } catch (Exception ex) {
+                // ignore no perminison
+            }
+        }
+
+        // try to get created channel number.
+        int channelId = Server.getActiveSessions().get(0).registerChannel(new ChannelSession());
+        Assert.assertTrue("create too many sftp channel more", channelId<30);
+
+        // try to set the local file to writable
+        Paths.get(AbstractVfsTestCase.getTestDirectory(),scratchFolder.getName().getBaseName(), fileName).toFile().setWritable(true);
+
+
+        fileObjectCopy = scratchFolder.resolveFile(fileName);
+        Assert.assertTrue(fileObjectCopy.isWriteable());
+        fileObjectCopy.copyFrom(localFileObject, Selectors.SELECT_SELF);
+
+
+
+    }
+
+    /**
+     * Creates the test suite for the sftp file system.
+     */
+    public static junit.framework.Test suite() throws Exception {
+        final SftpProviderTestSuite suite = new SftpProviderTestSuite(new SftpPermissionExceptionTestCase()){
+            @Override
+            protected void addBaseTests() throws Exception {
+                // Just tries to read
+                addTests(SftpPermissionExceptionTestCase.class);
+            }
+        };
+        return suite;
+    }
+
+    @Override
+    protected boolean isExecChannelClosed() {
+        return false;
+    }
+}


### PR DESCRIPTION
Try to copy a file from local to sftp server, if the sftp target directory can't write by the sftp user, it throw a exception as below.

```
Caused by: org.apache.commons.vfs2.FileSystemException: Could not write to "sftp://sftpuser:***@localhost/noperms/test.dat.tmp".
	at org.apache.commons.vfs2.provider.AbstractFileObject.getOutputStream(AbstractFileObject.java:1270)
	at org.apache.commons.vfs2.provider.DefaultFileContent.buildOutputStream(DefaultFileContent.java:540)
	at org.apache.commons.vfs2.provider.DefaultFileContent.getOutputStream(DefaultFileContent.java:406)
	at org.apache.commons.vfs2.provider.DefaultFileContent.getOutputStream(DefaultFileContent.java:394)
	at org.apache.commons.vfs2.provider.DefaultFileContent.write(DefaultFileContent.java:815)
	at org.apache.commons.vfs2.provider.DefaultFileContent.write(DefaultFileContent.java:833)
	at org.apache.commons.vfs2.FileUtil.copyContent(FileUtil.java:37)
	at org.apache.commons.vfs2.provider.AbstractFileObject.copyFrom(AbstractFileObject.java:297)
	... 29 common frames omitted
Caused by: com.jcraft.jsch.SftpException: Permission denied
	at com.jcraft.jsch.ChannelSftp.throwStatusError(ChannelSftp.java:2873)
	at com.jcraft.jsch.ChannelSftp.put(ChannelSftp.java:768)
	at com.jcraft.jsch.ChannelSftp.put(ChannelSftp.java:709)
	at com.jcraft.jsch.ChannelSftp.put(ChannelSftp.java:706)
	at org.apache.commons.vfs2.provider.sftp.SftpFileObject.doGetOutputStream(SftpFileObject.java:483)
	at org.apache.commons.vfs2.provider.AbstractFileObject.getOutputStream(AbstractFileObject.java:1266)
	... 36 common frames omitted
```
the exception is from the version 2.5.0.

the retry times is more than 20, then the exception stack as below:
```
Caused by: org.apache.commons.vfs2.FileSystemException: Could not connect to SFTP server at "sftp://sftpuser:***@localhost/".
	at org.apache.commons.vfs2.provider.sftp.SftpFileSystem.getChannel(SftpFileSystem.java:159)
	at org.apache.commons.vfs2.provider.sftp.SftpFileObject.statSelf(SftpFileObject.java:106)
	at org.apache.commons.vfs2.provider.sftp.SftpFileObject.doGetType(SftpFileObject.java:76)
	at org.apache.commons.vfs2.provider.AbstractFileObject.getType(AbstractFileObject.java:1368)
	... 30 common frames omitted
Caused by: com.jcraft.jsch.JSchException: channel is not opened.
	at com.jcraft.jsch.Channel.sendChannelOpen(Channel.java:768)
	at com.jcraft.jsch.Channel.connect(Channel.java:151)
	at org.apache.commons.vfs2.provider.sftp.SftpFileSystem.getChannel(SftpFileSystem.java:133)
	... 33 common frames omitted
```

Although the sftp directory permission problem is fixed, the file cannot be copied to the sftp target directory, and the error stack still `channel is not opened`.

The PR  try to catch  the exception on `SftpFileObject.doGetOutputStream`,  if there is a exception on the method `channel.put`, use the `getAbstractFileSystem().putChannel(channel)` to return the channel to the pool.

