### PR TITLE
VFS-810: Use different UriBuilder for Http4FileSystem

### DIFF
--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/WebDav4FilesTestCase.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/WebDav4FilesTestCase.java
@@ -34,7 +34,7 @@ public class WebDav4FilesTestCase extends TestCase {
      */
     @Test
     public void testUrlWithAuthority() throws FileSystemException {
-        final String urlWithAuthority = "webdav4://alice\\1234:secret@localhost:80";
+        final String urlWithAuthority = "webdav4://alice%5C1234:secret@localhost:80";
 
         final FileSystemManager fileSystemManager = VFS.getManager();
 

--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/WebDav4FilesTestCase.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/WebDav4FilesTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.webdav4.test;
+
+import junit.framework.TestCase;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests https://issues.apache.org/jira/browse/VFS-810
+ */
+public class WebDav4FilesTestCase extends TestCase {
+
+    /**
+     * Tests https://issues.apache.org/jira/browse/VFS-810
+     */
+    @Test
+    public void testUrlWithAuthority() throws FileSystemException {
+        final String urlWithAuthority = "webdav4://alice\\1234:secret@localhost:80";
+
+        final FileSystemManager fileSystemManager = VFS.getManager();
+
+        final FileObject file = fileSystemManager.resolveFile(urlWithAuthority);
+        Assert.assertEquals("webdav4://alice\\1234:secret@localhost/", file.getURL().toExternalForm());
+    }
+}

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -176,7 +176,6 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http4/Http4FileSystem.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.provider.http4;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
+import javax.ws.rs.core.UriBuilder;
 
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileName;
@@ -70,9 +71,10 @@ public class Http4FileSystem extends AbstractFileSystem {
 
         // if scheme is 'http*s' or 'HTTP*S', then the internal base URI should be 'https'. 'http' otherwise.
         if (lastCharOfScheme == 's' || lastCharOfScheme == 'S') {
-            this.internalBaseURI = URI.create("https" + rootURI.substring(offset));
+            // UriBuilder::fromPath will try to parse it using URI::create, if it fails, it reconstructs the url part by part
+            this.internalBaseURI = UriBuilder.fromPath("https" + rootURI.substring(offset)).build();
         } else {
-            this.internalBaseURI = URI.create("http" + rootURI.substring(offset));
+            this.internalBaseURI = UriBuilder.fromPath("http" + rootURI.substring(offset)).build();
         }
 
         this.httpClient = httpClient;

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FilesCacheTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FilesCacheTestCase.java
@@ -50,4 +50,18 @@ public class Http4FilesCacheTestCase extends TestCase {
         final FileObject queryFile2 = fileSystemManager.resolveFile(queryStringUrl2);
         Assert.assertEquals(queryStringUrl2, queryFile2.getURL().toExternalForm()); // failed for VFS-426
     }
+
+
+    /**
+     * Tests https://issues.apache.org/jira/browse/VFS-810
+     */
+    @Test
+    public void testUrlWithAuthority() throws FileSystemException {
+        final String urlWithAuthority = "http4://alice\\1234:secret@localhost:80";
+
+        final FileSystemManager fileSystemManager = VFS.getManager();
+
+        final FileObject file = fileSystemManager.resolveFile(urlWithAuthority);
+        Assert.assertEquals("http4://alice\\1234:secret@localhost/", file.getURL().toExternalForm());
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FilesCacheTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4FilesCacheTestCase.java
@@ -57,7 +57,7 @@ public class Http4FilesCacheTestCase extends TestCase {
      */
     @Test
     public void testUrlWithAuthority() throws FileSystemException {
-        final String urlWithAuthority = "http4://alice\\1234:secret@localhost:80";
+        final String urlWithAuthority = "http4://alice%5C1234:secret@localhost:80";
 
         final FileSystemManager fileSystemManager = VFS.getManager();
 


### PR DESCRIPTION
There is an issue when parsing urls containing backslashes in Http4FileSystem and derived classes.

https://issues.apache.org/jira/browse/VFS-810

