### PR TITLE
VFS-818 root has read and write permissions also if he is not owner

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -49,6 +49,8 @@ import com.jcraft.jsch.SftpException;
  */
 public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
+    private static final int ROOT_USER_ID = 0;
+
     /**
      * An InputStream that monitors for end-of-file.
      */
@@ -471,8 +473,10 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
                 }
             }
         }
-        final boolean isOwner = checkIds && attrs.getUId() == getAbstractFileSystem().getUId();
-        return new PosixPermissions(attrs.getPermissions(), isOwner, isInGroup);
+        boolean sameUser = attrs.getUId() == getAbstractFileSystem().getUId();
+        boolean isRoot = getAbstractFileSystem().getUId() == ROOT_USER_ID;
+        final boolean isOwner = checkIds && sameUser;
+        return new PosixPermissions(attrs.getPermissions(), isOwner, isInGroup, isRoot);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/UserIsOwnerPosixPermissions.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/UserIsOwnerPosixPermissions.java
@@ -29,6 +29,6 @@ public class UserIsOwnerPosixPermissions extends PosixPermissions {
      * @param permissions permission bits.
      */
     public UserIsOwnerPosixPermissions(final int permissions) {
-        super(permissions, true, true);
+        super(permissions, true, true, false);
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/PosixPermissions.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/PosixPermissions.java
@@ -113,16 +113,23 @@ public class PosixPermissions {
     private final boolean isInGroup;
 
     /**
+     * If the user is root. The user root has always read and write permissions.
+     */
+    private final boolean isRoot;
+
+    /**
      * Creates a new PosixPermissions object.
      *
      * @param permissions The permissions
      * @param isOwner true if the user is the owner of the file
      * @param isInGroup true if the user is a group owner of the file
+     * @param isRoot true if the user is root
      */
-    public PosixPermissions(final int permissions, final boolean isOwner, final boolean isInGroup) {
+    public PosixPermissions(final int permissions, final boolean isOwner, final boolean isInGroup, final boolean isRoot) {
         this.permissions = permissions;
         this.isOwner = isOwner;
         this.isInGroup = isInGroup;
+        this.isRoot = isRoot;
     }
 
     /**
@@ -183,6 +190,9 @@ public class PosixPermissions {
      * @return whether the permissions are readable.
      */
     public boolean isReadable() {
+        if(this.isRoot) {
+            return true;
+        }
         if (this.isOwner) {
             return this.get(Type.UserReadable);
         }
@@ -198,6 +208,9 @@ public class PosixPermissions {
      * @return whether the permissions are writable.
      */
     public boolean isWritable() {
+        if(this.isRoot) {
+            return true;
+        }
         if (this.isOwner) {
             return this.get(Type.UserWritable);
         }


### PR DESCRIPTION
If the permission of a file is 000 the user root can read and write, but not execute the file. If the permission of the file is 600 and the owner is a other user the user root can also read and write file.