### PR TITLE
SFTP: Memory leak because AbstractFileProvider#findFileSystem fails to detect equality of SFTP FileSystemOptions

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/BytesIdentityInfo.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/BytesIdentityInfo.java
@@ -20,6 +20,8 @@ package org.apache.commons.vfs2.provider.sftp;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 
+import java.util.Arrays;
+
 /**
  * Structure for an identity based on byte arrays.
  *
@@ -56,6 +58,24 @@ public class BytesIdentityInfo implements IdentityProvider {
         this.privateKey = privateKey;
         this.publicKey = publicKey;
         this.passPhrase = passPhrase;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BytesIdentityInfo) {
+            BytesIdentityInfo other = (BytesIdentityInfo) o;
+            return Arrays.equals(passPhrase, other.passPhrase) && Arrays.equals(privateKey, other.privateKey) &&
+                Arrays.equals(publicKey, other.publicKey);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Arrays.hashCode(passPhrase);
+        result = prime * result + Arrays.hashCode(privateKey);
+        return prime * result + Arrays.hashCode(publicKey);
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
@@ -17,6 +17,7 @@
 package org.apache.commons.vfs2.provider.sftp;
 
 import java.io.File;
+import java.util.Arrays;
 
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
@@ -79,6 +80,29 @@ public class IdentityInfo implements IdentityProvider {
         this.passPhrase = passPhrase;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IdentityInfo) {
+            final IdentityInfo other = (IdentityInfo) obj;
+            if (!Arrays.equals(passPhrase, other.passPhrase)) {
+                return false;
+            }
+            if (!isSameFile(privateKey, other.privateKey)) {
+                return false;
+            }
+            return isSameFile(publicKey, other.publicKey);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime + (passPhrase == null ? 0 : Arrays.hashCode(passPhrase));
+        result = prime * result + (privateKey == null ? 0 : privateKey.getAbsolutePath().hashCode());
+        return prime * result + (publicKey == null ? 0 : publicKey.getAbsolutePath().hashCode());
+    }
+
     /**
      * @since 2.4
      */
@@ -119,5 +143,12 @@ public class IdentityInfo implements IdentityProvider {
      */
     public File getPublicKey() {
         return publicKey;
+    }
+
+    private static boolean isSameFile(File a, File b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        return a.getAbsolutePath().equals(b.getAbsolutePath());
     }
 }


### PR DESCRIPTION
When using FileSystemManager as a singleton and performing repeated SFTP operations, SftpFileSystem instances will accumulate with every resolveFile() invocation.  The cause for this is that AbstractOriginatingFileProvider#getFileSystem fails to locate the FileSystem from a previous invocation inside the TreeMap because all implementations of the SFTP IdentityProvider interface do not have equals() / hashCode() implementations and thus make calls to Arrays.deepHashcode() inside FileSystemOptions#compareTo always return different values, even if the FileSystemOption instances are actually equal.