### PR TITLE
Fix typos in code

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/ProviderConfiguration.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/ProviderConfiguration.java
@@ -29,7 +29,7 @@ public class ProviderConfiguration {
 
     private String className;
     private final List<String> schemes = new ArrayList<>(10);
-    private final List<String> dependenies = new ArrayList<>(10);
+    private final List<String> dependencies = new ArrayList<>(10);
 
     /**
      * Constructs a new instance.
@@ -52,7 +52,7 @@ public class ProviderConfiguration {
      * @return the dependency.
      */
     public List<String> getDependencies() {
-        return dependenies;
+        return dependencies;
     }
 
     /**
@@ -88,7 +88,7 @@ public class ProviderConfiguration {
      * @param dependency the dependency.
      */
     public void setDependency(final String dependency) {
-        dependenies.add(dependency);
+        dependencies.add(dependency);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/StandardFileSystemManager.java
@@ -427,7 +427,7 @@ public class StandardFileSystemManager extends DefaultFileSystemManager {
 
     private ClassLoader validateClassLoader(final ClassLoader clazzLoader, final Class<?> clazz) {
         return Objects.requireNonNull(clazzLoader, "The class loader for " + clazz
-                + " is null; some Java implementions use null for the bootstrap class loader.");
+                + " is null; some Java implementations use null for the bootstrap class loader.");
     }
 
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DelegateFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DelegateFileObject.java
@@ -278,8 +278,8 @@ public class DelegateFileObject<AFS extends AbstractFileSystem> extends Abstract
      * @since 2.0
      */
     @Override
-    protected void doRemoveAttribute(final String atttrName) throws Exception {
-        getFileContent().removeAttribute(atttrName);
+    protected void doRemoveAttribute(final String attrName) throws Exception {
+        getFileContent().removeAttribute(attrName);
     }
 
     /**
@@ -298,8 +298,8 @@ public class DelegateFileObject<AFS extends AbstractFileSystem> extends Abstract
      * Sets an attribute of this file.
      */
     @Override
-    protected void doSetAttribute(final String atttrName, final Object value) throws Exception {
-        getFileContent().setAttribute(atttrName, value);
+    protected void doSetAttribute(final String attrName, final Object value) throws Exception {
+        getFileContent().setAttribute(attrName, value);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileObject.java
@@ -307,7 +307,7 @@ public class HdfsFileObject extends AbstractFileObject<HdfsFileSystem> {
         } catch (final FileNotFoundException fne) {
             return false;
         } catch (final Exception e) {
-            throw new FileSystemException("Unable to check existance ", e);
+            throw new FileSystemException("Unable to check existence ", e);
         }
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ram/RamFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ram/RamFileObject.java
@@ -82,7 +82,7 @@ public class RamFileObject extends AbstractFileObject<RamFileSystem> {
     protected void doDelete() throws Exception {
 
         if (this.isContentOpen()) {
-            throw new FileSystemException(this.getName() + " cannot be deleted while the file is openg");
+            throw new FileSystemException(this.getName() + " cannot be deleted while the file is open");
         }
         getAbstractFileSystem().delete(this);
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -47,7 +47,7 @@ public class SftpFileSystem extends AbstractFileSystem {
 
     private static final Log LOG = LogFactory.getLog(SftpFileSystem.class);
 
-    private static final int UNIDENTIFED = -1;
+    private static final int UNIDENTIFIED = -1;
 
     private static final int SLEEP_MILLIS = 100;
 
@@ -73,7 +73,7 @@ public class SftpFileSystem extends AbstractFileSystem {
      * DCL pattern requires that the ivar be volatile.
      * </p>
      */
-    private volatile int uid = UNIDENTIFED;
+    private volatile int uid = UNIDENTIFIED;
 
     /**
      * Cache for the user groups ids (null when not set)
@@ -124,7 +124,7 @@ public class SftpFileSystem extends AbstractFileSystem {
      */
     private boolean detectExecDisabled() {
         try {
-            return getUId() == UNIDENTIFED;
+            return getUId() == UNIDENTIFIED;
         } catch (final JSchException | IOException e) {
             LOG.debug("Cannot get UID, assuming no exec channel is present", e);
             return true;
@@ -312,9 +312,9 @@ public class SftpFileSystem extends AbstractFileSystem {
      * @since 2.1
      */
     public int getUId() throws JSchException, IOException {
-        if (uid == UNIDENTIFED) {
+        if (uid == UNIDENTIFIED) {
             synchronized (this) {
-                if (uid == UNIDENTIFED) {
+                if (uid == UNIDENTIFIED) {
                     final StringBuilder output = new StringBuilder();
                     final int code = executeCommand("id -u", output);
                     if (code != 0) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
@@ -566,24 +566,24 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      * Sets the identity info (your private key files).
      *
      * @param options      The FileSystem options.
-     * @param identites An array of identity info.
+     * @param identities An array of identity info.
      * @since 2.1
      * @deprecated Use {@link #setIdentityProvider(FileSystemOptions,IdentityProvider...)}
      */
     @Deprecated
-    public void setIdentityInfo(final FileSystemOptions options, final IdentityInfo... identites) {
-        this.setParam(options, IDENTITIES, identites);
+    public void setIdentityInfo(final FileSystemOptions options, final IdentityInfo... identities) {
+        this.setParam(options, IDENTITIES, identities);
     }
 
     /**
      * Sets the identity info (your private key files).
      *
      * @param options      The FileSystem options.
-     * @param identites An array of identity info.
+     * @param identities An array of identity info.
      * @since 2.4
      */
-    public void setIdentityProvider(final FileSystemOptions options, final IdentityProvider... identites) {
-        this.setParam(options, IDENTITIES, identites);
+    public void setIdentityProvider(final FileSystemOptions options, final IdentityProvider... identities) {
+        this.setParam(options, IDENTITIES, identities);
     }
 
     /**
@@ -605,11 +605,11 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      * diffie-hellman-group-exchange-sha256, diffie-hellman-group-exchange-sha1, diffie-hellman-group1-sha1.
      *
      * @param options                The FileSystem options.
-     * @param keyExchangeAlgoritm The key exchange algorithm picked.
+     * @param keyExchangeAlgorithm The key exchange algorithm picked.
      * @since 2.4
      */
-    public void setKeyExchangeAlgorithm(final FileSystemOptions options, final String keyExchangeAlgoritm) {
-        setParam(options, KEY_EXCHANGE_ALGORITHM, keyExchangeAlgoritm);
+    public void setKeyExchangeAlgorithm(final FileSystemOptions options, final String keyExchangeAlgorithm) {
+        setParam(options, KEY_EXCHANGE_ALGORITHM, keyExchangeAlgorithm);
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/DefaultCryptor.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/DefaultCryptor.java
@@ -53,11 +53,11 @@ public class DefaultCryptor implements Cryptor {
         for (int i = 0; i < length; i++) {
             final int id1 = indexOf(HEX_CHARS, chars[index++]);
             if (id1 == INDEX_NOT_FOUND) {
-                throw new IllegalArgumentException("Character " + chars[index - 1] + " at position " + (index - 1) + " is not a valid hexidecimal character");
+                throw new IllegalArgumentException("Character " + chars[index - 1] + " at position " + (index - 1) + " is not a valid hexadecimal character");
             }
             final int id2 = indexOf(HEX_CHARS, chars[index++]);
             if (id2 == INDEX_NOT_FOUND) {
-                throw new IllegalArgumentException("Character " + chars[index - 1] + " at position " + (index - 1) + " is not a valid hexidecimal character");
+                throw new IllegalArgumentException("Character " + chars[index - 1] + " at position " + (index - 1) + " is not a valid hexadecimal character");
             }
             decoded[i] = (byte) ((id1 << BITS_IN_HALF_BYTE) | id2);
         }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/DelegatingFileSystemOptionsBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/DelegatingFileSystemOptionsBuilder.java
@@ -70,19 +70,19 @@ public class DelegatingFileSystemOptionsBuilder {
     }
     @SuppressWarnings("unchecked") // OK, it is a String
     private static final Class<String>[] STRING_PARAM = new Class[] {String.class};
-    private static final Map<String, Class<?>> PRIMATIVE_TO_OBJECT = new TreeMap<>();
+    private static final Map<String, Class<?>> PRIMITIVE_TO_OBJECT = new TreeMap<>();
 
     private static final Log log = LogFactory.getLog(DelegatingFileSystemOptionsBuilder.class);
     static {
-        PRIMATIVE_TO_OBJECT.put(Void.TYPE.getName(), Void.class);
-        PRIMATIVE_TO_OBJECT.put(Boolean.TYPE.getName(), Boolean.class);
-        PRIMATIVE_TO_OBJECT.put(Byte.TYPE.getName(), Byte.class);
-        PRIMATIVE_TO_OBJECT.put(Character.TYPE.getName(), Character.class);
-        PRIMATIVE_TO_OBJECT.put(Short.TYPE.getName(), Short.class);
-        PRIMATIVE_TO_OBJECT.put(Integer.TYPE.getName(), Integer.class);
-        PRIMATIVE_TO_OBJECT.put(Long.TYPE.getName(), Long.class);
-        PRIMATIVE_TO_OBJECT.put(Double.TYPE.getName(), Double.class);
-        PRIMATIVE_TO_OBJECT.put(Float.TYPE.getName(), Float.class);
+        PRIMITIVE_TO_OBJECT.put(Void.TYPE.getName(), Void.class);
+        PRIMITIVE_TO_OBJECT.put(Boolean.TYPE.getName(), Boolean.class);
+        PRIMITIVE_TO_OBJECT.put(Byte.TYPE.getName(), Byte.class);
+        PRIMITIVE_TO_OBJECT.put(Character.TYPE.getName(), Character.class);
+        PRIMITIVE_TO_OBJECT.put(Short.TYPE.getName(), Short.class);
+        PRIMITIVE_TO_OBJECT.put(Integer.TYPE.getName(), Integer.class);
+        PRIMITIVE_TO_OBJECT.put(Long.TYPE.getName(), Long.class);
+        PRIMITIVE_TO_OBJECT.put(Double.TYPE.getName(), Double.class);
+        PRIMITIVE_TO_OBJECT.put(Float.TYPE.getName(), Float.class);
     }
 
     private final FileSystemManager manager;
@@ -126,7 +126,7 @@ public class DelegatingFileSystemOptionsBuilder {
         }
 
         if (type.isPrimitive()) {
-            final Class<?> objectType = PRIMATIVE_TO_OBJECT.get(type.getName());
+            final Class<?> objectType = PRIMITIVE_TO_OBJECT.get(type.getName());
             if (objectType == null) {
                 log.warn(Messages.getString("vfs.provider/config-unexpected-primitive.error", type.getName()));
                 return false;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIBitSets.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/URIBitSets.java
@@ -714,8 +714,8 @@ final class URIBitSets {
      * BitSet for control.
      */
     private static final int CHARACTER_DEL = 0x7F;
-    private static final int CHARCTER_US = 0x1F;
-    static final FluentBitSet CONTROL = bitSet().setInclusive(0, CHARCTER_US).set(CHARACTER_DEL);
+    private static final int CHARACTER_US = 0x1F;
+    static final FluentBitSet CONTROL = bitSet().setInclusive(0, CHARACTER_US).set(CHARACTER_DEL);
 
     private static final int NBITS = 256;
 

--- a/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
@@ -203,7 +203,7 @@ vfs.provider.temp/missing-share-name.error=Share name missing from UNC file name
 
 # SMB Provider
 vfs.provider.smb/missing-share-name.error=The share name is missing from URI "{0}".
-vfs.provider.smb/get-type.error=Could not detemine the type of "{0}".
+vfs.provider.smb/get-type.error=Could not determine the type of "{0}".
 
 # Zip Provider
 vfs.provider.zip/open-zip-file.error=Could not open Zip file "{0}".

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/ContentTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/ContentTests.java
@@ -310,7 +310,7 @@ public class ContentTests extends AbstractProviderTestCase {
      * Tests concurrent reads on a file.
      */
     @Test
-    public void testReadSingleSequencial() throws Exception {
+    public void testReadSingleSequential() throws Exception {
         final FileObject file = getReadFolder().resolveFile("file1.txt");
         assertTrue(file.exists());
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/LastModifiedTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/LastModifiedTests.java
@@ -67,7 +67,7 @@ public class LastModifiedTests extends AbstractProviderTestCase {
      * @throws FileSystemException if error occurred
      */
     @Test
-    public void testGetAccurary() throws FileSystemException {
+    public void testGetAccuracy() throws FileSystemException {
         final FileObject file = getReadFolder().resolveFile("file1.txt");
         final long lastModTimeAccuracyMillis = (long) file.getFileSystem().getLastModTimeAccuracy();
         // System.out.println("Accuracy on " + file.getFileSystem().getRootURI() + " is " + lastModTimeAccuracy + " as

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderWriteAppendTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderWriteAppendTests.java
@@ -94,7 +94,7 @@ public class ProviderWriteAppendTests extends AbstractProviderTestCase {
      * See [VFS-807].
      */
     @Test
-    public void testAppendToNonExsiting() throws Exception {
+    public void testAppendToNonExisting() throws Exception {
         try (FileObject scratchFolder = createScratchFolder();
 
             // Create direct child of the test folder

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderWriteTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderWriteTests.java
@@ -326,7 +326,7 @@ public class ProviderWriteTests extends AbstractProviderTestCase {
      * Tests deletion
      */
     @Test
-    public void testDeleteAllDescendents() throws Exception {
+    public void testDeleteAllDescendants() throws Exception {
         // Set up the test structure
         final FileObject folder = createScratchFolder();
         folder.resolveFile("file1.txt").createFile();

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/operations/BasicOperationsTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/operations/BasicOperationsTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public class BasicOperationsTest {
 
     /** This FileOperationsProvider is a VfsComponent and records invocations. */
-    static class MyFileOperationProviderComp extends MyFileOprationProviderBase implements VfsComponent {
+    static class MyFileOperationProviderComp extends MyFileOperationProviderBase implements VfsComponent {
         @Override
         public void close() {
             ops |= 8;
@@ -68,13 +68,13 @@ public class BasicOperationsTest {
     }
 
     /** This FileOperationsProvider is no VfsComponent. */
-    static class MyFileOperationProviderNoncomp extends MyFileOprationProviderBase {
+    static class MyFileOperationProviderNoncomp extends MyFileOperationProviderBase {
     }
 
     /**
      * Base class for different Test Providers. This is also a compile test to ensure interface stability.
      */
-    static class MyFileOprationProviderBase implements FileOperationProvider {
+    static class MyFileOperationProviderBase implements FileOperationProvider {
         int ops; // bit array to record invocations (poor man's mock)
 
         @Override
@@ -89,7 +89,7 @@ public class BasicOperationsTest {
         public FileOperation getOperation(final FileObject file, final Class<? extends FileOperation> operationClass)
                 throws FileSystemException {
             assertNotNull(file, "file object");
-            assertNotNull(operationClass, "operationclass");
+            assertNotNull(operationClass, "operationClass");
             ops |= 32;
             return null;
         }
@@ -131,7 +131,7 @@ public class BasicOperationsTest {
      */
     @Test
     public void testLifecycleComp() throws FileSystemException {
-        final MyFileOprationProviderBase myop = new MyFileOperationProviderComp();
+        final MyFileOperationProviderBase myop = new MyFileOperationProviderComp();
         assertEquals(0, myop.ops);
         manager.addOperationProvider("file", myop);
         assertEquals(7, myop.ops);
@@ -148,7 +148,7 @@ public class BasicOperationsTest {
      */
     @Test
     public void testLifecycleNoncomp() throws FileSystemException {
-        final MyFileOprationProviderBase myop = new MyFileOperationProviderNoncomp();
+        final MyFileOperationProviderBase myop = new MyFileOperationProviderNoncomp();
         manager.addOperationProvider("file", myop);
         final FileOperationProvider[] ops = manager.getOperationProviders("file");
         assertSame(1, ops.length, "exactly one provider registered");
@@ -163,7 +163,7 @@ public class BasicOperationsTest {
      */
     @Test
     public void testNotFoundAny() throws FileSystemException {
-        final MyFileOprationProviderBase myop = new MyFileOperationProviderNoncomp();
+        final MyFileOperationProviderBase myop = new MyFileOperationProviderNoncomp();
         manager.addOperationProvider("file", myop);
         final FileObject fo = manager.toFileObject(new File("."));
 
@@ -182,7 +182,7 @@ public class BasicOperationsTest {
      */
     @Test
     public void testNotFoundOperation() throws FileSystemException {
-        final MyFileOprationProviderBase myop = new MyFileOperationProviderNoncomp();
+        final MyFileOperationProviderBase myop = new MyFileOperationProviderNoncomp();
         manager.addOperationProvider("file", myop);
         final FileObject fo = manager.toFileObject(new File("."));
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http/HttpProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http/HttpProviderTestCase.java
@@ -181,7 +181,7 @@ public class HttpProviderTestCase extends AbstractProviderTestConfig {
         // TODO: should also check the created HTTPClient
     }
 
-    private void testResloveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
+    private void testResolveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
         VFS.getManager().getFilesCache().close();
         final FileSystemOptions opts = new FileSystemOptions();
         HttpFileSystemConfigBuilder.getInstance().setFollowRedirect(opts, followRedirect);
@@ -193,23 +193,23 @@ public class HttpProviderTestCase extends AbstractProviderTestConfig {
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", false);
+    public void testResolveFolderSlashNoRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", false);
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", true);
+    public void testResolveFolderSlashNoRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", true);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", false);
+    public void testResolveFolderSlashYesRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", false);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", true);
+    public void testResolveFolderSlashYesRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", true);
     }
 
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http4/Http4ProviderTestCase.java
@@ -183,7 +183,7 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
         assertEquals("foo/bar", builder.getUserAgent(opts));
     }
 
-    private void testResloveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
+    private void testResolveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
         VFS.getManager().getFilesCache().close();
         final FileSystemOptions opts = new FileSystemOptions();
         Http4FileSystemConfigBuilder.getInstance().setFollowRedirect(opts, followRedirect);
@@ -197,23 +197,23 @@ public class Http4ProviderTestCase extends AbstractProviderTestConfig {
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", false);
+    public void testResolveFolderSlashNoRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", false);
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", true);
+    public void testResolveFolderSlashNoRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", true);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", false);
+    public void testResolveFolderSlashYesRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", false);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", true);
+    public void testResolveFolderSlashYesRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", true);
     }
 
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5ProviderTestCase.java
@@ -178,7 +178,7 @@ public class Http5ProviderTestCase extends AbstractProviderTestConfig {
         assertEquals("foo/bar", builder.getUserAgent(opts));
     }
 
-    private void testResloveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
+    private void testResolveFolderSlash(final String uri, final boolean followRedirect) throws FileSystemException {
         VFS.getManager().getFilesCache().close();
         final FileSystemOptions opts = new FileSystemOptions();
         Http5FileSystemConfigBuilder.getInstance().setFollowRedirect(opts, followRedirect);
@@ -191,23 +191,23 @@ public class Http5ProviderTestCase extends AbstractProviderTestConfig {
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", false);
+    public void testResolveFolderSlashNoRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", false);
     }
 
     @Test
-    public void testResloveFolderSlashNoRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests", true);
+    public void testResolveFolderSlashNoRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests", true);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOff() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", false);
+    public void testResolveFolderSlashYesRedirectOff() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", false);
     }
 
     @Test
-    public void testResloveFolderSlashYesRedirectOn() throws FileSystemException {
-        testResloveFolderSlash(ConnectionUri + "/read-tests/", true);
+    public void testResolveFolderSlashYesRedirectOn() throws FileSystemException {
+        testResolveFolderSlash(ConnectionUri + "/read-tests/", true);
     }
 
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/TarFileSystemTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/tar/TarFileSystemTest.java
@@ -41,7 +41,7 @@ public class TarFileSystemTest {
     }
 
     @Test
-    public void testTbz2FileUseDefautlFilesCache() throws FileSystemException {
+    public void testTbz2FileUseDefaultFilesCache() throws FileSystemException {
         testUseWeakRefFilesCache("tbz2", "src/test/resources/test-data/test.tbz2", null);
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/util/DelegatingFileSystemOptionsBuilderTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/util/DelegatingFileSystemOptionsBuilderTest.java
@@ -70,10 +70,10 @@ public class DelegatingFileSystemOptionsBuilderTest {
     @Test
     public void testDelegatingBad() throws Throwable {
         final FileSystemOptions opts = new FileSystemOptions();
-        final DelegatingFileSystemOptionsBuilder delgate = new DelegatingFileSystemOptionsBuilder(fsm);
+        final DelegatingFileSystemOptionsBuilder delegate = new DelegatingFileSystemOptionsBuilder(fsm);
 
         try {
-            delgate.setConfigString(opts, "http", "proxyPort", "wrong_port");
+            delegate.setConfigString(opts, "http", "proxyPort", "wrong_port");
             fail();
         } catch (final FileSystemException e) {
             assertSame(e.getCause().getClass(), InvocationTargetException.class);
@@ -82,7 +82,7 @@ public class DelegatingFileSystemOptionsBuilderTest {
         }
 
         try {
-            delgate.setConfigClass(opts, "sftp", "userinfo", String.class);
+            delegate.setConfigClass(opts, "sftp", "userinfo", String.class);
             fail();
         } catch (final FileSystemException e) {
             assertEquals(e.getCode(), "vfs.provider/config-value-invalid.error");
@@ -94,12 +94,12 @@ public class DelegatingFileSystemOptionsBuilderTest {
         final String[] identityPaths = { "/file1", "/file2", };
 
         final FileSystemOptions opts = new FileSystemOptions();
-        final DelegatingFileSystemOptionsBuilder delgate = new DelegatingFileSystemOptionsBuilder(fsm);
+        final DelegatingFileSystemOptionsBuilder delegate = new DelegatingFileSystemOptionsBuilder(fsm);
 
-        delgate.setConfigString(opts, "http", "proxyHost", "proxy");
-        delgate.setConfigString(opts, "http", "proxyPort", "8080");
-        delgate.setConfigClass(opts, "sftp", "userinfo", TrustEveryoneUserInfo.class);
-        delgate.setConfigStrings(opts, "sftp", "identities", identityPaths);
+        delegate.setConfigString(opts, "http", "proxyHost", "proxy");
+        delegate.setConfigString(opts, "http", "proxyPort", "8080");
+        delegate.setConfigClass(opts, "sftp", "userinfo", TrustEveryoneUserInfo.class);
+        delegate.setConfigStrings(opts, "sftp", "identities", identityPaths);
 
         assertEquals("http.proxyHost", HttpFileSystemConfigBuilder.getInstance().getProxyHost(opts), "proxy");
         assertEquals("http.proxyPort", HttpFileSystemConfigBuilder.getInstance().getProxyPort(opts), 8080);


### PR DESCRIPTION
Fix various typos in code :

- private field or constant names,
- method attribute names,
- test class and method names,
- exception messages.

Those changes should not be problematic : they do not belog to the public API (except maybe the exception messages).