### PR TITLE
Handle the case where a user does not have any groups

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -261,19 +261,31 @@ public class SftpFileSystem extends AbstractFileSystem {
                         throw new JSchException(
                                 "Could not get the groups id of the current user (error code: " + code + ")");
                     }
-                    // Retrieve the different groups
-                    final String[] groups = output.toString().trim().split("\\s+");
 
-                    // Deal with potential empty groups
-                    this.groupsIds = Arrays.stream(groups)
-                        .map(String::trim)
-                        .filter(s -> !s.isEmpty())
-                        .mapToInt(Integer::parseInt)
-                        .toArray();
+                    this.groupsIds = parseGroupIdOutput(output);
                 }
             }
         }
         return groupsIds;
+    }
+
+    /**
+     * Parses the output of the 'id -G' command
+     *
+     * @param output The output from the command
+     * @return the (numeric) group IDs.
+     * @since 2.10
+     */
+    int[] parseGroupIdOutput(StringBuilder output) {
+        // Retrieve the different groups
+        final String[] groups = output.toString().trim().split("\\s+");
+
+        // Deal with potential empty groups
+        return Arrays.stream(groups)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .mapToInt(Integer::parseInt)
+            .toArray();
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -274,7 +274,6 @@ public class SftpFileSystem extends AbstractFileSystem {
      *
      * @param output The output from the command
      * @return the (numeric) group IDs.
-     * @since 2.10
      */
     int[] parseGroupIdOutput(StringBuilder output) {
         // Retrieve the different groups

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -263,12 +264,12 @@ public class SftpFileSystem extends AbstractFileSystem {
                     // Retrieve the different groups
                     final String[] groups = output.toString().trim().split("\\s+");
 
-                    final int[] groupsIds = new int[groups.length];
-                    for (int i = 0; i < groups.length; i++) {
-                        groupsIds[i] = Integer.parseInt(groups[i]);
-                    }
-                    this.groupsIds = groupsIds;
-
+                    // Deal with potential empty groups
+                    this.groupsIds = Arrays.stream(groups)
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .mapToInt(Integer::parseInt)
+                        .toArray();
                 }
             }
         }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
@@ -26,9 +26,9 @@ import org.junit.Test;
 
 public class SftpFileSystemGroupsTests {
 
-    FileSystemOptions options = new FileSystemOptions();
-    Session session;
-    SftpFileSystem fileSystem;
+    private final FileSystemOptions options = new FileSystemOptions();
+    private Session session;
+    private SftpFileSystem fileSystem;
 
     @Before
     public void setup() throws JSchException {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.commons.vfs2.provider.sftp;
 
 import com.jcraft.jsch.JSch;

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemGroupsTests.java
@@ -1,0 +1,45 @@
+package org.apache.commons.vfs2.provider.sftp;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SftpFileSystemGroupsTests {
+
+    FileSystemOptions options = new FileSystemOptions();
+    Session session;
+    SftpFileSystem fileSystem;
+
+    @Before
+    public void setup() throws JSchException {
+        session = new JSch().getSession("");
+        fileSystem = new SftpFileSystem(null, session, options);
+    }
+
+    @Test
+    public void shouldHandleEmptyGroupResult() {
+        StringBuilder builder = new StringBuilder("\n");
+        int[] groups = fileSystem.parseGroupIdOutput(builder);
+
+        Assert.assertEquals("Group ids should be empty", 0, groups.length);
+    }
+
+    @Test
+    public void shouldHandleListOfGroupIds() {
+        StringBuilder builder = new StringBuilder("1 22 333 4444\n");
+        int[] groups = fileSystem.parseGroupIdOutput(builder);
+
+        Assert.assertEquals("Group ids should not be empty", 4, groups.length);
+        Assert.assertArrayEquals(new int[]{1, 22, 333, 4444}, groups);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void shouldThrowOnUnexpectedOutput() {
+        StringBuilder builder = new StringBuilder("abc\n");
+        fileSystem.parseGroupIdOutput(builder);
+    }
+}


### PR DESCRIPTION
id -g would return the gid 0
id -G however would return only a newline resulting in a NumberFormatException