### PR TITLE
Fix links in javadoc and documentations

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -76,14 +76,14 @@ o           Bump commons.javadoc.version from 3.2.0 to 3.3.0. Thanks to Gary Gre
 o           Update from to javax.mail:mail 1.4.7 to com.sun.mail:jakarta.mail 1.6.7. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS Project, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS Project website:
 
-http://commons.apache.org/proper/commons-vfs/
+https://commons.apache.org/proper/commons-vfs/
 
-Download page: http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download page: https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -166,14 +166,14 @@ o VFS-795:  Code improvements for SoftRefFilesCache (simplify loop, use isEmpty,
 o           Update commons-lang3 3.11 -> 3.12.0. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS Project, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS Project website:
 
-http://commons.apache.org/proper/commons-vfs/
+https://commons.apache.org/proper/commons-vfs/
 
-Download page: http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download page: https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -239,14 +239,14 @@ o           Update Apache Commons Net from 3.6 to 3.7.2. Thanks to Gary Gregory.
 o           Update JUnit from 4.13 to 4.13.1. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS Project, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS Project website:
 
-http://commons.apache.org/proper/commons-vfs/
+https://commons.apache.org/proper/commons-vfs/
 
-Download page: http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download page: https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -271,14 +271,14 @@ Changes:
 o           Update JUnit from 4.12 to 4.13. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS Project, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS Project website:
 
-http://commons.apache.org/proper/commons-vfs/
+https://commons.apache.org/proper/commons-vfs/
 
-Download page: http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download page: https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -326,14 +326,14 @@ o           Update tests using org.mockito:mockito-core from 3.0.0 to 3.1.0. Tha
 o VFS-749:  Update Apache Commons Parent from 48 to 50. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-http://commons.apache.org/proper/commons-vfs/
+https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -355,14 +355,14 @@ o VFS-724:  FileContent#getByteArray() throws IllegalArgumentException: Buffer s
 o           Javadoc fixes. Thanks to Gary Gregory.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-Visit http://commons.apache.org/proper/commons-vfs/
+Visit https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -419,14 +419,14 @@ o           Public API note: The overridden method org.apache.commons.vfs2.provi
 o           Public API note: The overridden method org.apache.commons.vfs2.provider.sftp.SftpFileProvider#init() was removed but is implemented in a superclass.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-Visit http://commons.apache.org/proper/commons-vfs/
+Visit https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -478,14 +478,14 @@ o VFS-682:  Throw a org.apache.commons.vfs2.FileSystemException instead of a Nul
 o VFS-688:  [SFTP] Update jsch from 0.1.54 to 0.1.55.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-Visit http://commons.apache.org/proper/commons-vfs/
+Visit https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -524,14 +524,14 @@ Known Problems:
 o VFS-645:  VfsClassLoaderTests fails on Java 9.
 
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-Visit http://commons.apache.org/proper/commons-vfs/
+Visit https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------
 
@@ -745,13 +745,13 @@ o VFS-361:  Upgrade commons collections version to 3.2.1.
 Removed:
 o VFS-469:  Remove unused dependency to javax.jcr:jcr.
 
-Historical list of changes: http://commons.apache.org/proper/commons-vfs/changes-report.html
+Historical list of changes: https://commons.apache.org/proper/commons-vfs/changes-report.html
 
 For complete information on Apache Commons VFS, including instructions on how to submit bug reports,
 patches, or suggestions for improvement, see the Apache Apache Commons VFS website:
 
-Visit http://commons.apache.org/proper/commons-vfs/
+Visit https://commons.apache.org/proper/commons-vfs/
 
-Download it from http://commons.apache.org/proper/commons-vfs/download_vfs.cgi
+Download it from https://commons.apache.org/proper/commons-vfs/download_vfs.cgi
 
 -----------------------------------------------------------------------------

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -26,25 +26,25 @@
   <property name="localeLanguage" value="en" />
 
   <!-- Checks that a package-info.java file exists for each package. -->
-  <!-- See http://checkstyle.sourceforge.net/config_javadoc.html -->
+  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
   <module name="JavadocPackage" />
 
   <!-- Checks whether files end with a new line. -->
-  <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
   <module name="NewlineAtEndOfFile" />
 
   <!-- Checks that property files contain the same keys. -->
-  <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
   <module name="Translation" />
 
   <!-- Checks for Tab characters -->
-  <!-- See http://checkstyle.sourceforge.net/config_whitespace.html#FileTabCharacter -->
+  <!-- See https://checkstyle.org/config_whitespace.html#FileTabCharacter -->
   <module name="FileTabCharacter">
     <property name="fileExtensions" value="java" />
   </module>
 
   <!-- Checks for white space at the end of the line -->
-  <!-- See http://checkstyle.sourceforge.net/config_regexp.html -->
+  <!-- See https://checkstyle.org/config_regexp.html#RegexpSingleline -->
   <module name="RegexpSingleline">
     <property name="format" value="\s+$" />
     <property name="message" value="Line has trailing spaces." />
@@ -68,7 +68,7 @@
   </module>
 
   <!-- Checks for Size Violations. -->
-  <!-- See http://checkstyle.sf.net/config_sizes.html -->
+  <!-- See https://checkstyle.org/config_sizes.html#LineLength -->
   <module name="LineLength">
     <property name="max" value="160" />
   </module>
@@ -81,13 +81,13 @@
   <module name="TreeWalker">
 
     <!-- Checks for Javadoc comments. -->
-    <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
     <module name="JavadocMethod">
       <property name="accessModifiers" value="public" />
     </module>
     <module name="MissingJavadocMethod"/>
 
-    <!-- http://checkstyle.sourceforge.net/config_javadoc.html#JavadocType -->
+    <!-- https://checkstyle.org/config_javadoc.html#JavadocType -->
     <module name="JavadocType">
       <!-- It is unfortunate to have to do this but checkstyle doesn't allow custom tags -->
       <property name="allowUnknownTags" value="true" />
@@ -100,7 +100,7 @@
     </module>
 
     <!-- Checks for Naming Conventions. -->
-    <!-- See http://checkstyle.sf.net/config_naming.html -->
+    <!-- See https://checkstyle.org/config_naming.html -->
     <module name="ConstantName">
       <property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$|^capabilities$|^log$" />
     </module>
@@ -117,14 +117,14 @@
     <!-- <module name="RegexpHeader"/> -->
 
     <!-- Checks for imports -->
-    <!-- See http://checkstyle.sf.net/config_import.html -->
+    <!-- See https://checkstyle.org/config_imports.html -->
     <module name="AvoidStarImport" />
     <module name="IllegalImport" /> <!-- defaults to sun.* packages -->
     <module name="RedundantImport" />
     <module name="UnusedImports" />
 
     <!-- Checks for Size Violations. -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
     <!--<module name="FileLength"/> -->
     <module name="MethodLength" />
     <module name="ParameterNumber">
@@ -132,7 +132,7 @@
     </module>
 
     <!-- Checks for whitespace -->
-    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
     <module name="EmptyForIteratorPad" />
     <module name="NoWhitespaceAfter" />
     <module name="NoWhitespaceBefore" />
@@ -146,12 +146,12 @@
     <module name="GenericWhitespace" />
 
     <!-- Modifier Checks -->
-    <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+    <!-- See https://checkstyle.org/config_modifier.html -->
     <module name="ModifierOrder" />
     <module name="RedundantModifier" />
 
     <!-- Checks for blocks. You know, those {}'s -->
-    <!-- See http://checkstyle.sf.net/config_blocks.html -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
     <module name="AvoidNestedBlocks" />
     <!-- Require empty catch blocks to have at least a comment -->
     <module name="EmptyBlock">
@@ -167,7 +167,7 @@
     </module>
 
     <!-- Checks for common coding problems -->
-    <!-- See http://checkstyle.sf.net/config_coding.html -->
+    <!-- See https://checkstyle.org/config_coding.html -->
     <module name="CovariantEquals" />
     <module name="EqualsHashCode" />
     <module name="IllegalInstantiation" />
@@ -188,7 +188,7 @@
     <!-- <module name="UnnecessaryParentheses"/> -->
 
     <!-- Checks for class design -->
-    <!-- See http://checkstyle.sf.net/config_design.html -->
+    <!-- See https://checkstyle.org/config_design.html -->
     <module name="FinalClass" />
     <module name="HideUtilityClassConstructor" />
     <module name="InterfaceIsType" />
@@ -197,7 +197,7 @@
     </module>
 
     <!-- Miscellaneous other checks. -->
-    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <!-- See https://checkstyle.org/config_misc.html -->
     <module name="ArrayTypeStyle" />
     <module name="TodoComment">
       <property name="severity" value="info" />

--- a/commons-vfs2-examples/README.md
+++ b/commons-vfs2-examples/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons VFS Examples homepage](https://commons.apache.org/proper/commons-vfs).
-The [Javadoc](https://commons.apache.org/proper/commons-vfs/apidocs) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-vfs/commons-vfs2/apidocs/index.html) can be browsed.
 Questions related to the usage of Apache Commons VFS Examples should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-vfs2-sandbox/src/site/xdoc/index.xml
+++ b/commons-vfs2-sandbox/src/site/xdoc/index.xml
@@ -30,7 +30,7 @@
           providers</a>) which cannot be shipped with the official Apache release.
           This includes experimental code as well as components which have 
           <a href="dependencies.html">dependencies</a> not compatible with the 
-          <a href="http://www.apache.org/legal/resolved.html#category-x">ASF redistribution policy
+          <a href="https://www.apache.org/legal/resolved.html#category-x">ASF redistribution policy
           (especially LGPL)</a>.
         </p><p>
           To build the sandbox binaries, see the <a href="../download.html">download and build

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -24,7 +24,7 @@
   <name>Apache Commons VFS</name>
   <artifactId>commons-vfs2</artifactId>
   <description>Apache Commons VFS is a Virtual File System library.</description>
-  <url>http://commons.apache.org/proper/commons-vfs/</url>
+  <url>https://commons.apache.org/proper/commons-vfs/</url>
 
   <parent>
     <groupId>org.apache.commons</groupId>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/AgeFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/AgeFileFilter.java
@@ -47,7 +47,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class AgeFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/AndFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/AndFileFilter.java
@@ -34,7 +34,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * when the first filter returns {@code false}.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class AndFileFilter implements FileFilter, ConditionalFileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanExecuteFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanExecuteFileFilter.java
@@ -52,7 +52,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * }
  * </pre>
  *
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class CanExecuteFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanReadFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanReadFileFilter.java
@@ -67,7 +67,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class CanReadFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanWriteFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/CanWriteFileFilter.java
@@ -61,7 +61,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * </p>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class CanWriteFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/ConditionalFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/ConditionalFileFilter.java
@@ -24,7 +24,7 @@ import org.apache.commons.vfs2.FileFilter;
  * Defines operations for conditional file filters.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public interface ConditionalFileFilter {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/DirectoryFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/DirectoryFileFilter.java
@@ -40,7 +40,7 @@ import org.apache.commons.vfs2.FileType;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class DirectoryFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/EmptyFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/EmptyFileFilter.java
@@ -57,7 +57,7 @@ import org.apache.commons.vfs2.FileType;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class EmptyFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/FalseFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/FalseFileFilter.java
@@ -25,7 +25,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * A file filter that always returns false.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class FalseFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/FileFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/FileFileFilter.java
@@ -40,7 +40,7 @@ import org.apache.commons.vfs2.FileType;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class FileFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/HiddenFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/HiddenFileFilter.java
@@ -53,7 +53,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class HiddenFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/IOCase.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/IOCase.java
@@ -35,7 +35,7 @@ import java.io.File;
  * </p>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public enum IOCase {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/NameFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/NameFileFilter.java
@@ -41,7 +41,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class NameFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/NotFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/NotFileFilter.java
@@ -26,7 +26,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * This filter produces a logical NOT of the filters specified.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class NotFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/OrFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/OrFileFilter.java
@@ -33,7 +33,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * file filter list stops when the first filter returns {@code true}.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class OrFileFilter implements FileFilter, ConditionalFileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/PrefixFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/PrefixFileFilter.java
@@ -41,7 +41,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class PrefixFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/RegexFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/RegexFileFilter.java
@@ -43,7 +43,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class RegexFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/SizeFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/SizeFileFilter.java
@@ -43,7 +43,7 @@ import org.apache.commons.vfs2.FileSystemException;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class SizeFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/SuffixFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/SuffixFileFilter.java
@@ -42,7 +42,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class SuffixFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/TrueFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/TrueFileFilter.java
@@ -25,7 +25,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * A file filter that always returns true.
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class TrueFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/WildcardFileFilter.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/filter/WildcardFileFilter.java
@@ -54,7 +54,7 @@ import org.apache.commons.vfs2.FileSelectInfo;
  * </pre>
  *
  * @author This code was originally ported from Apache Commons IO File Filter
- * @see "http://commons.apache.org/proper/commons-io/"
+ * @see "https://commons.apache.org/proper/commons-io/"
  * @since 2.4
  */
 public class WildcardFileFilter implements FileFilter, Serializable {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
@@ -35,7 +35,7 @@ public abstract class AbstractFileName implements FileName {
     //
     // URIs can contain :, /, ?, #, @
     // See https://docs.oracle.com/javase/8/docs/api/java/net/URI.html
-    // http://tools.ietf.org/html/rfc3986#section-2.2
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
     //
     // Since : and / occur before the path, only chars after path are escaped (i.e., # and ?)
     // ? is a reserved filesystem character for Windows and Unix, so can't be part of a file name.

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsDataChannelProtectionLevel.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsDataChannelProtectionLevel.java
@@ -25,7 +25,7 @@ package org.apache.commons.vfs2.provider.ftps;
  * <li>P - Private</li>
  * </ul>
  *
- * @see <a href="http://tools.ietf.org/html/rfc2228#section-3">RFC 2228, section 3</a>
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc2228#section-3">RFC 2228, section 3</a>
  * @since 2.1
  */
 public enum FtpsDataChannelProtectionLevel {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsFileSystemConfigBuilder.java
@@ -145,7 +145,7 @@ public final class FtpsFileSystemConfigBuilder extends FtpFileSystemConfigBuilde
      *
      * @param opts The FileSystemOptions.
      * @param ftpsMode The mode to establish a FTPS connection.
-     * @see <a href="http://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
+     * @see <a href="https://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
      * @since 2.1
      */
     public void setFtpsMode(final FileSystemOptions opts, final FtpsMode ftpsMode) {
@@ -162,7 +162,7 @@ public final class FtpsFileSystemConfigBuilder extends FtpFileSystemConfigBuilde
      *
      * @param opts The FileSystemOptions.
      * @param ftpsType The file type.
-     * @see <a href="http://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
+     * @see <a href="https://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
      * @deprecated As of 2.1, use {@link #setFtpsMode(FileSystemOptions, FtpsMode)}
      */
     @Deprecated

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsMode.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsMode.java
@@ -24,7 +24,7 @@ package org.apache.commons.vfs2.provider.ftps;
  * mode and it is not yet clear if its a problem with Commons VFS/Commons Net or our test server Apache FTP/SSHD.
  * </p>
  *
- * @see <a href="http://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
+ * @see <a href="https://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
  * @since 2.1
  */
 public enum FtpsMode {
@@ -36,7 +36,7 @@ public enum FtpsMode {
      * mode and it is not yet clear if its a problem with Commons VFS/Commons Net or our test server Apache FTP/SSHD.
      * </p>
      *
-     * @see <a href="http://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
+     * @see <a href="https://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
      */
     IMPLICIT,
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftps/FtpsProviderImplicitTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftps/FtpsProviderImplicitTestCase.java
@@ -24,7 +24,7 @@ import junit.framework.Test;
  * TODO: Fails for concurrent access. Note, that the implicit mode is not standardized and the protocol may differ
  * between the FTPS servers.
  *
- * @see <a href="http://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
+ * @see <a href="https://en.wikipedia.org/wiki/FTPS#Implicit">Wikipedia: FTPS/Implicit</a>
  */
 public class FtpsProviderImplicitTestCase extends AbstractFtpsProviderTestCase {
 

--- a/commons-vfs2/src/test/resources/log4j.properties
+++ b/commons-vfs2/src/test/resources/log4j.properties
@@ -25,7 +25,7 @@ log4j.rootLogger=ERROR, Console
 ###############################################################################
 # The console log
 #
-# Documentation: http://logging.apache.org/log4j/docs/api/org/apache/log4j/ConsoleAppender.html
+# Documentation: https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/appender/ConsoleAppender.html
 #
 # To enable this appender, add its name to the log4j.rootLogger list
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <packaging>pom</packaging>
   <version>2.10.0-SNAPSHOT</version>
 
-  <url>http://commons.apache.org/proper/commons-vfs/</url>
+  <url>https://commons.apache.org/proper/commons-vfs/</url>
   <inceptionYear>2002</inceptionYear>
 
   <modules>
@@ -116,7 +116,7 @@
       <name>Bernd Eckenfels</name>
       <id>ecki</id>
       <email>ecki -at- apache.org</email>
-      <url>http://bernd.eckenfels.net</url>
+      <url>https://bernd.eckenfels.net</url>
       <timezone>+1</timezone>
     </developer>
   </developers>

--- a/src/changes/release-notes.vm
+++ b/src/changes/release-notes.vm
@@ -25,7 +25,7 @@ $introduction.replaceAll("(?<!\015)\012", "
 ").replaceAll("(?m)^ +","")
 
 ## N.B. the available variables are described here:
-## http://maven.apache.org/plugins/maven-changes-plugin/examples/using-a-custom-announcement-template.html
+## https://maven.apache.org/plugins/maven-changes-plugin/examples/using-a-custom-announcement-template.html
 ##
 ## Hack to improve layout: replace all pairs of spaces with a single new-line
 $release.description.replaceAll("  ", "

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -34,7 +34,7 @@
       <item name="Javadocs Archive"        href="https://javadoc.io/doc/org.apache.commons/commons-vfs2/latest/index.html"/>
       <item name="File Systems"            href="/filesystems.html"/>
       <item name="Ant Tasks"               href="/anttasks.html"/>
-      <item name="Wiki"                    href="http://wiki.apache.org/commons/VFS"/>
+      <item name="Wiki"                    href="https://cwiki.apache.org/confluence/display/commons/VFS"/>
     </menu>
 
     <menu name="VFS Development" inherit="top">

--- a/src/site/xdoc/build.xml
+++ b/src/site/xdoc/build.xml
@@ -38,46 +38,46 @@
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/logging/">Apache Commons Logging</a>
+                        <a href="https://commons.apache.org/proper/commons-logging/">Apache Commons Logging</a>
                     </td>
                     <td>All</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/lang/">Apache Commons Lang</a>
+                        <a href="https://commons.apache.org/proper/commons-lang/">Apache Commons Lang</a>
                     </td>
                     <td>All</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/collections/">Apache Commons Collections</a>
+                        <a href="https://commons.apache.org/proper/commons-collections/">Apache Commons Collections</a>
                     </td>
                     <td>LRU Cache (optional)</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/compress/">Apache Commons Compress</a>
+                        <a href="https://commons.apache.org/proper/commons-compress/">Apache Commons Compress</a>
                     </td>
                     <td>TAR, Bzip2</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/net/">Apache Commons Net</a>
+                        <a href="https://commons.apache.org/proper/commons-net/">Apache Commons Net</a>
                     </td>
                     <td>FTP</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://commons.apache.org/httpclient/">Apache Commons Httpclient</a><br/>
-                        Requires <a href="http://commons.apache.org/proper/commons-codec/">Commons Codec</a>
+                        <a href="https://hc.apache.org/httpclient-legacy/">Apache Commons Httpclient</a><br/>
+                        Requires <a href="https://commons.apache.org/proper/commons-codec/">Commons Codec</a>
                     </td>
                     <td>WebDAV, HTTP, URI Utils</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://jackrabbit.apache.org/jackrabbit-webdav-library.html">Apache Jackrabbit WebDAV Library</a><br/>
-                        Requires <a href="http://jackrabbit.apache.org/jackrabbit-jcr-commons.html">Jackrabbit JCR Commons</a>
-                        and <a href="http://www.slf4j.org">SLF4J</a> (Api and Impl).
+                        <a href="https://jackrabbit.apache.org/jcr/components/jackrabbit-webdav-library.html">Apache Jackrabbit WebDAV Library</a><br/>
+                        Requires <a href="https://jackrabbit.apache.org/jcr/components/jackrabbit-jcr-commons.html">Jackrabbit JCR Commons</a>
+                        and <a href="https://www.slf4j.org">SLF4J</a> (Api and Impl).
                     </td>
                     <td>WebDAV</td>
                 </tr>
@@ -89,21 +89,21 @@
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://hadoop.apache.org/docs/stable/">Apache Hadoop Common</a><br/>
-                        <a href="http://hadoop.apache.org/docs/stable/">Apache Hadoop HDFS Common</a><br/>
+                        <a href="https://hadoop.apache.org/docs/stable/">Apache Hadoop Common</a><br/>
+                        <a href="https://hadoop.apache.org/docs/stable/">Apache Hadoop HDFS Common</a><br/>
                         This requires a number of dependencies, use <code>$HADOOP_HOME/bin/hadoop classpath</code> command.
                     </td>
                     <td>HDFS</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://jcifs.samba.org/">jCIFS</a>
+                        <a href="https://jcifs.samba.org/">jCIFS</a>
                     </td>
                     <td>CIFS (VFS sandbox)</td>
                 </tr>
                 <tr>
                     <td>
-                        <a href="http://java.sun.com/products/javamail/">javamail</a>
+                        <a href="https://javaee.github.io/javamail/">javamail</a>
                     </td>
                     <td>mime (VFS sandbox)</td>
                 </tr>
@@ -111,7 +111,7 @@
         </section>
         <section name="Building Commons VFS">
             <p>
-                To build Commons VFS, get the <a href="scm.html">sources</a> and use <a href="http://maven.apache.org">Apache Maven</a> 3.2.5 or later.
+                To build Commons VFS, get the <a href="scm.html">sources</a> and use <a href="https://maven.apache.org/">Apache Maven</a> 3.2.5 or later.
                 You need to use Java 8 or later. Production builds can be done with the
                 <code>-Pjava-1.8</code> profile from Commons Parent (which will compile and test with a JDK
                 from the JAVA_1_8_HOME environment variable).

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -148,9 +148,9 @@
             methods for provider interfaces (like <code>FileObject</code>). If you implement a VFS provider and use the
             corresponding <code>Abstract*</code> or <code>Default*</code> classes, there should be no need to modify
             the code or recompile the provider. The TarFileProvider is one known exception to compatibility with 2.0.
-            See the <a href="https://dist.apache.org/repos/dist/dev/commons/vfs/RELEASE-NOTES.txt">Release Notes</a> and the
-            <a href="commons-vfs2/clirr-report.html">Clirr Report</a> for details. VFS 2.1 adds a new read-only provider
-            for the Apache Hadoop (HDFS) File system.
+            See the <a href="https://dist.apache.org/repos/dist/release/commons/vfs/RELEASE-NOTES.txt">Release Notes</a>
+            and the <a href="commons-vfs2/clirr-report.html">Clirr Report</a> for details. VFS 2.1 adds a new read-only
+            provider for the Apache Hadoop (HDFS) File system.
           </p>
           <p>
             Apache Commons VFS 2.0 adds support for FTPS and WebDav have been added in addition to many bugs

--- a/src/site/xdoc/testing.xml
+++ b/src/site/xdoc/testing.xml
@@ -25,31 +25,31 @@
             <p>
               Apache Commons VFS comes with a suite of (nearly 2000) tests (in <code>core/src/test</code>). The JUnit framework
               is used, and executed at build time via the Maven
-              <a href="http://maven.apache.org/surefire/maven-surefire-plugin/">Surefire plugin</a> by the <code>mvn test</code> goal.
+              <a href="https://maven.apache.org/surefire/maven-surefire-plugin/">Surefire plugin</a> by the <code>mvn test</code> goal.
               If you plan to contribute a patch for a bug or feature, make sure to also provide a test
               which can reproduce the bug or exercise the new feature. Also run the whole test suite against the patched code.
             </p>
             <p>
-              The <a href="http://junit.org">JUnit</a> tests will execute unit, compile but also integration tests to test the API and the implementation.
+              The <a href="https://junit.org">JUnit</a> tests will execute unit, compile but also integration tests to test the API and the implementation.
               The local file provider is tested in a directory of the local file system. Virtual providers (compression and archive)
               and resource access is based on this test directory as well. For testing the other providers some test servers are started.
               The following table described the details (for versions have a look in the
               <a href="commons-vfs2/dependencies.html#test">dependency report</a>):
             </p>
 <table><tr><th>Provider</th><th>Tested Against</th><th>External</th></tr>
-<tr><td>ftp</td><td><a href="http://mina.apache.org/ftpserver-project/">Apache FtpServer</a></td><td>-Pftp -Dtest.ftp.uri=ftp://test:test@localhost:123</td></tr>
-<tr><td>ftps</td><td><a href="http://mina.apache.org/ftpserver-project/">Apache FtpServer</a></td><td>-Pftps -Dtest.ftps.uri=ftps://test:test@localhost:123</td></tr>
-<tr><td>hdfs</td><td>Apache Hadoop HDFS (<a href="https://wiki.apache.org/hadoop/HowToDevelopUnitTests">MiniDFSCluster</a>)</td><td>-P!no-test-hdfs (see below)</td></tr>
+<tr><td>ftp</td><td><a href="https://mina.apache.org/ftpserver-project/">Apache FtpServer</a></td><td>-Pftp -Dtest.ftp.uri=ftp://test:test@localhost:123</td></tr>
+<tr><td>ftps</td><td><a href="https://mina.apache.org/ftpserver-project/">Apache FtpServer</a></td><td>-Pftps -Dtest.ftps.uri=ftps://test:test@localhost:123</td></tr>
+<tr><td>hdfs</td><td>Apache Hadoop HDFS (<a href="https://web.archive.org/web/20170706071449/https%3A//wiki.apache.org/hadoop/HowToDevelopUnitTests">MiniDFSCluster</a>)</td><td>-P!no-test-hdfs (see below)</td></tr>
 <tr><td>http</td><td>NHttpServer (local adaption of org.apache.http.examples.nio.NHttpServer)</td><td>-Phttp -Dtest.http.uri=http://localhost:123</td></tr>
 <tr><td>https</td><td>(not tested)</td><td>N/A</td></tr>
 <tr><td>jar</td><td>Local File Provider</td><td>N/A</td></tr>
 <tr><td>local</td><td>Local File system</td><td>N/A</td></tr>
 <tr><td>ram</td><td>In Memory test</td><td>N/A</td></tr>
 <tr><td>res</td><td>Local File Provider / JAR Provider</td><td>N/A</td></tr>
-<tr><td>sftp</td><td><a href="http://mina.apache.org/sshd-project/index.html">Apache SSHD</a></td><td>-Psftp -Dtest.sftp.uri=sftp://testtest@localhost:123</td></tr>
+<tr><td>sftp</td><td><a href="https://mina.apache.org/sshd-project/index.html">Apache SSHD</a></td><td>-Psftp -Dtest.sftp.uri=sftp://testtest@localhost:123</td></tr>
 <tr><td>tmp</td><td>Local File system</td><td>N/A</td></tr>
 <tr><td>url</td><td>NHttpServer (local adaption of org.apache.http.examples.nio.NHttpServer)<br/>Local File system</td><td>-Phttp -Dtest.http.uri=http://localhost:128</td></tr>
-<tr><td>webdav</td><td><a href="http://jackrabbit.apache.org/standalone-server.html">Apache Jackrabbit Standalone Server</a></td><td>-Pwebdav -Dtest.webdav.uri=webdav://admin@localhost:123/repository/default</td></tr>
+<tr><td>webdav</td><td><a href="https://jackrabbit.apache.org/jcr/standalone-server.html">Apache Jackrabbit Standalone Server</a></td><td>-Pwebdav -Dtest.webdav.uri=webdav://admin@localhost:123/repository/default</td></tr>
 <!-- <tr><td>webdavs</td><td>Apache Jackrabbit Standalone</td><td>-Pwebdav -Dtest.webdav.uri=webdav://admin@localhost:123/repository/default</td></tr> -->
 <tr><td>zip</td><td>Local File Provider</td><td>N/A</td></tr>
 <tr><td>smb (sandbox)</td><td>(not tested)</td><td>-Psmb -Dtest.smb.uri=smb://DOMAIN\User:Pass@host/C$/commons-vfs2/core/target/test-classes/test-data</td></tr>


### PR DESCRIPTION
- fix broken links,
- use direct links instead of redirects,
- use HTTPS where possible.