### PR TITLE
hadoop-hdfs-client is not set as optional

### DIFF
--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -61,6 +61,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
The hadoop-hdfs-client dependency isn't optional (and brings a whole bunch of dependencies in).

Since all the other hadoop dependencies (hadoop-common, hadoop-hdfs, etc) are optional I assume this was an oversight, so here's the PR to add it