### PR TITLE
AbstractFileObject uses the wrong exception for "cause"

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -1214,7 +1214,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
                     if (e instanceof FileSystemException) {
                         throw (FileSystemException) e;
                     }
-                    throw new FileSystemException("vfs.provider/read.error", fileName, exc);
+                    throw new FileSystemException("vfs.provider/read.error", fileName, e);
                 }
             }
             throw exc;


### PR DESCRIPTION
cc @garydgregory