### PR TITLE
[VFS-683] Class loader thread safety

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/FileObjectUtils.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/FileObjectUtils.java
@@ -82,12 +82,9 @@ public final class FileObjectUtils {
      * @since 2.6.0
      */
     public static byte[] getContentAsByteArray(final FileObject file) throws IOException {
-        synchronized(file.getFileSystem()) {
+        synchronized (file.getFileSystem()) {
             try (FileContent content = file.getContent()) {
                 return content.getByteArray();
-            } catch (NullPointerException npe) {
-                System.out.println("break here");
-                throw npe;
             }
         }
     }
@@ -102,7 +99,7 @@ public final class FileObjectUtils {
      * @since 2.4
      */
     public static String getContentAsString(final FileObject file, final Charset charset) throws IOException {
-        synchronized(file.getFileSystem()) {
+        synchronized (file.getFileSystem()) {
             try (FileContent content = file.getContent()) {
                 return content.getString(charset);
             }
@@ -119,7 +116,7 @@ public final class FileObjectUtils {
      * @since 2.4
      */
     public static String getContentAsString(final FileObject file, final String charset) throws IOException {
-        synchronized(file.getFileSystem()) {
+        synchronized (file.getFileSystem()) {
             try (FileContent content = file.getContent()) {
                 return content.getString(charset);
             }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/FileObjectUtils.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/FileObjectUtils.java
@@ -82,8 +82,13 @@ public final class FileObjectUtils {
      * @since 2.6.0
      */
     public static byte[] getContentAsByteArray(final FileObject file) throws IOException {
-        try (FileContent content = file.getContent()) {
-            return content.getByteArray();
+        synchronized(file.getFileSystem()) {
+            try (FileContent content = file.getContent()) {
+                return content.getByteArray();
+            } catch (NullPointerException npe) {
+                System.out.println("break here");
+                throw npe;
+            }
         }
     }
 
@@ -97,8 +102,10 @@ public final class FileObjectUtils {
      * @since 2.4
      */
     public static String getContentAsString(final FileObject file, final Charset charset) throws IOException {
-        try (FileContent content = file.getContent()) {
-            return content.getString(charset);
+        synchronized(file.getFileSystem()) {
+            try (FileContent content = file.getContent()) {
+                return content.getString(charset);
+            }
         }
     }
 
@@ -112,8 +119,10 @@ public final class FileObjectUtils {
      * @since 2.4
      */
     public static String getContentAsString(final FileObject file, final String charset) throws IOException {
-        try (FileContent content = file.getContent()) {
-            return content.getString(charset);
+        synchronized(file.getFileSystem()) {
+            try (FileContent content = file.getContent()) {
+                return content.getString(charset);
+            }
         }
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
@@ -217,37 +217,37 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
     @Test
     public void testThreadSafety() throws Exception {
         final int THREADS = 20;
-        BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(THREADS * 2);
-        List<Throwable> exceptions = new ArrayList<>();
-        Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {
+        final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(THREADS * 2);
+        final List<Throwable> exceptions = new ArrayList<>();
+        final Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread t, Throwable e) {
-                synchronized(exceptions) {
+                synchronized (exceptions) {
                     exceptions.add(e);
                 }
             }
         };
-        ThreadFactory factory = new ThreadFactoryBuilder().setUncaughtExceptionHandler(handler).build();
-        Queue<Runnable> rejections = new LinkedList<>();
-        RejectedExecutionHandler rejectionHandler = new RejectedExecutionHandler() {
+        final ThreadFactory factory = new ThreadFactoryBuilder().setUncaughtExceptionHandler(handler).build();
+        final Queue<Runnable> rejections = new LinkedList<>();
+        final RejectedExecutionHandler rejectionHandler = new RejectedExecutionHandler() {
             @Override
             public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-                synchronized(rejections) {
+                synchronized (rejections) {
                     rejections.add(r);
                 }
             }
         };
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(THREADS, THREADS, 0, TimeUnit.SECONDS, workQueue, factory, rejectionHandler);
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(THREADS, THREADS, 0, TimeUnit.SECONDS, workQueue, factory, rejectionHandler);
         executor.prestartAllCoreThreads();
         for (int i = 0; i < THREADS; i++) {
-            VFSClassLoader loader = createClassLoader();
+            final VFSClassLoader loader = createClassLoader();
             workQueue.put(new VfsClassLoaderTests.LoadClass(loader));
         }
         while (!workQueue.isEmpty()) {
             Thread.sleep(10);
         }
         while (!rejections.isEmpty() && executor.getActiveCount() > 0) {
-            List<Runnable> rejected = new ArrayList<>();
+            final List<Runnable> rejected = new ArrayList<>();
             synchronized(rejections) {
                 rejected.addAll(rejections);
                 rejections.clear();
@@ -257,12 +257,6 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
         executor.shutdown();
         executor.awaitTermination(30, TimeUnit.SECONDS);
         assertEquals(THREADS, executor.getCompletedTaskCount());
-        if (!exceptions.isEmpty()) {
-            for (Throwable t : exceptions) {
-                System.out.println(t.toString());
-                t.printStackTrace(System.out);
-            }
-        }
         assertTrue(exceptions.size() + " threads failed", exceptions.isEmpty());
     }
 
@@ -282,11 +276,7 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
 
                 final Object testObject = testClass.newInstance();
                 assertEquals("**PRIVATE**", testObject.toString());
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            } catch (InstantiationException e) {
-                throw new RuntimeException(e);
-            } catch (IllegalAccessException e) {
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
@@ -217,7 +217,7 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
 
     @Test
     public void testThreadSafety() throws Exception {
-        final int THREADS = 20;
+        final int THREADS = 40;
         final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(THREADS * 2);
         final List<Throwable> exceptions = new ArrayList<>();
         final Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
@@ -19,6 +19,7 @@ package org.apache.commons.vfs2.impl;
 import static org.apache.commons.vfs2.VfsTestUtils.getTestDirectoryFile;
 
 import java.io.File;
+import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.commons.vfs2.AbstractProviderTestCase;
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileObject;
@@ -263,7 +265,19 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
         executor.shutdown();
         executor.awaitTermination(30, TimeUnit.SECONDS);
         assertEquals(THREADS, executor.getCompletedTaskCount());
-        assertTrue(exceptions.size() + " threads failed", exceptions.isEmpty());
+        if (!exceptions.isEmpty()) {
+            StringBuilder exceptionMsg = new StringBuilder();
+            StringBuilderWriter writer = new StringBuilderWriter(exceptionMsg);
+            PrintWriter pWriter = new PrintWriter(writer);
+            for (Throwable t : exceptions) {
+                pWriter.write(t.getMessage());
+                pWriter.write('\n');
+                t.printStackTrace(pWriter);
+                pWriter.write('\n');
+            }
+            pWriter.flush();
+            assertTrue(exceptions.size() + " threads failed: " + exceptionMsg, exceptions.isEmpty());
+        }
     }
 
     private class LoadClass implements Runnable {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/VfsClassLoaderTests.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.vfs2.AbstractProviderTestCase;
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileObject;
@@ -227,7 +226,14 @@ public class VfsClassLoaderTests extends AbstractProviderTestCase {
                 }
             }
         };
-        final ThreadFactory factory = new ThreadFactoryBuilder().setUncaughtExceptionHandler(handler).build();
+        final ThreadFactory factory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r, "VfsClassLoaderTests.testThreadSafety");
+                thread.setUncaughtExceptionHandler(handler);
+                return thread;
+            }
+        };
         final Queue<Runnable> rejections = new LinkedList<>();
         final RejectedExecutionHandler rejectionHandler = new RejectedExecutionHandler() {
             @Override


### PR DESCRIPTION
* To ensure that the closing of files does not interfere with
*   reading the content, the FileObjectUtils read methods must
*   be synchronized on the underlying filesystem just like the
*   close AbstractFileObject close and detach methods.
* Added a test case that demostrated the issue.