### PR TITLE
Bump Hadoop client from 3.3.5 to 3.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     </commons.osgi.import>
     <!-- Avoid warnings about being unable to find jars during site building -->
     <dependency.locations.enabled>false</dependency.locations.enabled>
-    <hadoop.version>3.3.5</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <httpcore5.version>5.2.2</httpcore5.version>
     <httpclient5.version>5.2.1</httpclient5.version>
     <jackrabbit1.version>1.6.5</jackrabbit1.version>


### PR DESCRIPTION
Dependabot did not pick this up for some reason
