### PR TITLE
VFS-843: Close the HttpConnection after consuming the entire HttpEntity.

### DIFF
--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -95,10 +95,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             try {
                 final HttpVersionControl request = new HttpVersionControl(urlStr);
                 setupRequest(request);
-                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                    //close the underlying HTTP connection which is held by the response object
+                // AutoClose the underlying HTTP connection which is held by the response object
+                try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                    return true;
                 }
-                return true;
             } catch (final Exception ex) {
                 return false;
             }
@@ -138,10 +138,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                     try {
                         final HttpCheckout request = new HttpCheckout(urlStr);
                         setupRequest(request);
-                        try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                            //close the underlying HTTP connection which is held by the response object
+                        // AutoClose the underlying HTTP connection which is held by the response object
+                        try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                            isCheckedIn = false;
                         }
-                        isCheckedIn = false;
                     } catch (final FileSystemException ex) {
                         log(ex);
                     }
@@ -151,19 +151,19 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                     final HttpPut request = new HttpPut(urlStr);
                     request.setEntity(entity);
                     setupRequest(request);
-                    try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                        //close the underlying HTTP connection which is held by the response object
+                    // AutoClose the underlying HTTP connection which is held by the response object
+                    try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                        setUserName(fileName, urlStr);
                     }
-                    setUserName(fileName, urlStr);
                 } catch (final FileSystemException ex) {
                     if (!isCheckedIn) {
                         try {
                             final HttpCheckin request = new HttpCheckin(urlStr);
                             setupRequest(request);
-                            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                                //close the underlying HTTP connection which is held by the response object
+                            // AutoClose the underlying HTTP connection which is held by the response object
+                            try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                                isCheckedIn = true;
                             }
-                            isCheckedIn = true;
                         } catch (final Exception e) {
                             // Going to throw original.
                             log(e);
@@ -183,22 +183,23 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                 if (!isCheckedIn) {
                     final HttpCheckin request = new HttpCheckin(urlStr);
                     setupRequest(request);
-                    try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                        //close the underlying HTTP connection which is held by the response object
+                    // AutoClose the underlying HTTP connection which is held by the response object
+                    try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                        isCheckedIn = true;
                     }
                 }
             } else {
                 final HttpPut request = new HttpPut(urlStr);
                 request.setEntity(entity);
                 setupRequest(request);
-                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                    //close the underlying HTTP connection which is held by the response object
-                }
-                try {
-                    setUserName(fileName, urlStr);
-                } catch (final IOException e) {
-                    // Unable to set the user name.
-                    log(e);
+                // AutoClose the underlying HTTP connection which is held by the response object
+                try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                    try {
+                        setUserName(fileName, urlStr);
+                    } catch (final IOException e) {
+                        // Unable to set the user name.
+                        log(e);
+                    }
                 }
             }
             ((DefaultFileContent) this.file.getContent()).resetAttributes();
@@ -218,8 +219,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             setProperties.add(new DefaultDavProperty<>(DeltaVConstants.CREATOR_DISPLAYNAME, name));
             final HttpProppatch request = new HttpProppatch(urlStr, setProperties, removeProperties);
             setupRequest(request);
-            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                //close the underlying HTTP connection which is held by the response object
+            // AutoClose the underlying HTTP connection which is held by the response object
+            try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                // TODO: workaround due to PMD violation 'Empty try body - you could rename the resource to 'ignored'
+                request.succeeded(res);
             }
         }
     }
@@ -269,8 +272,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         final HttpMkcol request = new HttpMkcol(toUrlString((GenericURLFileName) getName()));
         setupRequest(request);
         try {
-            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-                //close the underlying HTTP connection which is held by the response object
+            // AutoClose the underlying HTTP connection which is held by the response object
+            try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+                // TODO: workaround due to PMD violation 'Empty try body - you could rename the resource to 'ignored'
+                request.succeeded(res);
             }
         } catch (final FileSystemException fse) {
             throw new FileSystemException("vfs.provider.webdav/create-collection.error", getName(), fse);
@@ -284,8 +289,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
     protected void doDelete() throws Exception {
         final HttpDelete request = new HttpDelete(toUrlString((GenericURLFileName) getName()));
         setupRequest(request);
-        try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
-            //close the underlying HTTP connection which is held by the response object
+        // AutoClose the underlying HTTP connection which is held by the response object
+        try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+            // TODO: workaround due to PMD violation 'Empty try body - you could rename the resource to 'ignored'
+            request.succeeded(res);
         }
     }
 
@@ -404,7 +411,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
 
                 request = new HttpPropfind(toUrlString(name), nameSet, DavConstants.DEPTH_1);
 
-                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
                     final List<Webdav4FileObject> vfs = new ArrayList<>();
                     if (request.succeeded(res)) {
                         final MultiStatusResponse[] responses = request.getResponseBodyAsMultiStatus(res).getResponses();
@@ -430,10 +437,6 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             throw fnfe;
         } catch (final DavException | IOException e) {
             throw new FileSystemException(e.getMessage(), e);
-        } finally {
-            if (request != null) {
-                request.releaseConnection();
-            }
         }
     }
 
@@ -446,8 +449,10 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         final String dest = toUrlString((GenericURLFileName) newFile.getName(), false);
         final HttpMove request = new HttpMove(url, dest, false);
         setupRequest(request);
-        try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)){
-            //close the underlying HTTP connection which is held by the response object
+        // AutoClose the underlying HTTP connection which is held by the response object
+        try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
+            // TODO: workaround due to PMD violation 'Empty try body - you could rename the resource to 'ignored'
+            request.succeeded(res);
         }
     }
 
@@ -470,8 +475,8 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
 
             final HttpProppatch request = new HttpProppatch(urlStr, properties, propertyNameSet);
             setupRequest(request);
-            //final HttpResponse response = executeRequest(request);
-            try (CloseableHttpResponse response = (CloseableHttpResponse) executeRequest(request)){
+            // AutoClose the underlying HTTP connection which is held by the response object
+            try (CloseableHttpResponse response = (CloseableHttpResponse) executeRequest(request)) {
                 if (!request.succeeded(response)) {
                     throw new FileSystemException("Property '" + attrName + "' could not be set.");
                 }
@@ -527,7 +532,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             final String urlStr = toUrlString(name);
             final HttpPropfind request = new HttpPropfind(urlStr, type, nameSet, DavConstants.DEPTH_0);
             setupRequest(request);
-            try(final CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+            try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)) {
                 if (request.succeeded(res)) {
                     final MultiStatus multiStatus = request.getResponseBodyAsMultiStatus(res);
                     final MultiStatusResponse response = multiStatus.getResponses()[0];

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -42,8 +42,8 @@ import org.apache.commons.vfs2.util.URIUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.DateUtils;
 import org.apache.http.entity.ByteArrayEntity;
@@ -95,7 +95,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             try {
                 final HttpVersionControl request = new HttpVersionControl(urlStr);
                 setupRequest(request);
-                executeRequest(request);
+                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                    //close the underlying HTTP connection which is held by the response object
+                }
                 return true;
             } catch (final Exception ex) {
                 return false;
@@ -136,7 +138,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                     try {
                         final HttpCheckout request = new HttpCheckout(urlStr);
                         setupRequest(request);
-                        executeRequest(request);
+                        try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                            //close the underlying HTTP connection which is held by the response object
+                        }
                         isCheckedIn = false;
                     } catch (final FileSystemException ex) {
                         log(ex);
@@ -147,14 +151,18 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                     final HttpPut request = new HttpPut(urlStr);
                     request.setEntity(entity);
                     setupRequest(request);
-                    executeRequest(request);
+                    try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                        //close the underlying HTTP connection which is held by the response object
+                    }
                     setUserName(fileName, urlStr);
                 } catch (final FileSystemException ex) {
                     if (!isCheckedIn) {
                         try {
                             final HttpCheckin request = new HttpCheckin(urlStr);
                             setupRequest(request);
-                            executeRequest(request);
+                            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                                //close the underlying HTTP connection which is held by the response object
+                            }
                             isCheckedIn = true;
                         } catch (final Exception e) {
                             // Going to throw original.
@@ -175,13 +183,17 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
                 if (!isCheckedIn) {
                     final HttpCheckin request = new HttpCheckin(urlStr);
                     setupRequest(request);
-                    executeRequest(request);
+                    try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                        //close the underlying HTTP connection which is held by the response object
+                    }
                 }
             } else {
                 final HttpPut request = new HttpPut(urlStr);
                 request.setEntity(entity);
                 setupRequest(request);
-                executeRequest(request);
+                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                    //close the underlying HTTP connection which is held by the response object
+                }
                 try {
                     setUserName(fileName, urlStr);
                 } catch (final IOException e) {
@@ -206,7 +218,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             setProperties.add(new DefaultDavProperty<>(DeltaVConstants.CREATOR_DISPLAYNAME, name));
             final HttpProppatch request = new HttpProppatch(urlStr, setProperties, removeProperties);
             setupRequest(request);
-            executeRequest(request);
+            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                //close the underlying HTTP connection which is held by the response object
+            }
         }
     }
 
@@ -255,7 +269,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         final HttpMkcol request = new HttpMkcol(toUrlString((GenericURLFileName) getName()));
         setupRequest(request);
         try {
-            executeRequest(request);
+            try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                //close the underlying HTTP connection which is held by the response object
+            }
         } catch (final FileSystemException fse) {
             throw new FileSystemException("vfs.provider.webdav/create-collection.error", getName(), fse);
         }
@@ -268,7 +284,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
     protected void doDelete() throws Exception {
         final HttpDelete request = new HttpDelete(toUrlString((GenericURLFileName) getName()));
         setupRequest(request);
-        executeRequest(request);
+        try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+            //close the underlying HTTP connection which is held by the response object
+        }
     }
 
     /**
@@ -386,25 +404,26 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
 
                 request = new HttpPropfind(toUrlString(name), nameSet, DavConstants.DEPTH_1);
 
-                final HttpResponse res = executeRequest(request);
-                final List<Webdav4FileObject> vfs = new ArrayList<>();
-                if (request.succeeded(res)) {
-                    final MultiStatusResponse[] responses = request.getResponseBodyAsMultiStatus(res).getResponses();
+                try(CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                    final List<Webdav4FileObject> vfs = new ArrayList<>();
+                    if (request.succeeded(res)) {
+                        final MultiStatusResponse[] responses = request.getResponseBodyAsMultiStatus(res).getResponses();
 
-                    for (final MultiStatusResponse response : responses) {
-                        if (isCurrentFile(response.getHref(), name)) {
-                            continue;
-                        }
-                        final String resourceName = resourceName(response.getHref());
-                        if (!resourceName.isEmpty()) {
-                            final Webdav4FileObject fo = (Webdav4FileObject) FileObjectUtils.getAbstractFileObject(
-                                    getFileSystem().resolveFile(getFileSystem().getFileSystemManager()
-                                            .resolveName(getName(), resourceName, NameScope.CHILD)));
-                            vfs.add(fo);
+                        for (final MultiStatusResponse response : responses) {
+                            if (isCurrentFile(response.getHref(), name)) {
+                                continue;
+                            }
+                            final String resourceName = resourceName(response.getHref());
+                            if (!resourceName.isEmpty()) {
+                                final Webdav4FileObject fo = (Webdav4FileObject) FileObjectUtils.getAbstractFileObject(
+                                        getFileSystem().resolveFile(getFileSystem().getFileSystemManager()
+                                                .resolveName(getName(), resourceName, NameScope.CHILD)));
+                                vfs.add(fo);
+                            }
                         }
                     }
+                    return vfs.toArray(EMPTY_ARRAY);
                 }
-                return vfs.toArray(EMPTY_ARRAY);
             }
             throw new FileNotFolderException(getName());
         } catch (final FileNotFolderException fnfe) {
@@ -427,7 +446,9 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
         final String dest = toUrlString((GenericURLFileName) newFile.getName(), false);
         final HttpMove request = new HttpMove(url, dest, false);
         setupRequest(request);
-        executeRequest(request);
+        try (CloseableHttpResponse res = (CloseableHttpResponse) executeRequest(request)){
+            //close the underlying HTTP connection which is held by the response object
+        }
     }
 
     /**
@@ -449,9 +470,11 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
 
             final HttpProppatch request = new HttpProppatch(urlStr, properties, propertyNameSet);
             setupRequest(request);
-            final HttpResponse response = executeRequest(request);
-            if (!request.succeeded(response)) {
-                throw new FileSystemException("Property '" + attrName + "' could not be set.");
+            //final HttpResponse response = executeRequest(request);
+            try (CloseableHttpResponse response = (CloseableHttpResponse) executeRequest(request)){
+                if (!request.succeeded(response)) {
+                    throw new FileSystemException("Property '" + attrName + "' could not be set.");
+                }
             }
         } catch (final FileSystemException fse) {
             throw fse;
@@ -481,10 +504,6 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             throw new FileSystemException(e);
         } catch (final DavException e) {
             throw ExceptionConverter.generate(e);
-        } finally {
-            if (request instanceof HttpRequestBase) {
-                ((HttpRequestBase) request).releaseConnection();
-            }
         }
     }
 
@@ -508,20 +527,21 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
             final String urlStr = toUrlString(name);
             final HttpPropfind request = new HttpPropfind(urlStr, type, nameSet, DavConstants.DEPTH_0);
             setupRequest(request);
-            final HttpResponse res = executeRequest(request);
-            if (request.succeeded(res)) {
-                final MultiStatus multiStatus = request.getResponseBodyAsMultiStatus(res);
-                final MultiStatusResponse response = multiStatus.getResponses()[0];
-                final DavPropertySet props = response.getProperties(HttpStatus.SC_OK);
-                if (addEncoding) {
-                    final ContentType resContentType = ContentType.getOrDefault(res.getEntity());
-                    final DavProperty<String> prop = new DefaultDavProperty<>(RESPONSE_CHARSET,
-                            resContentType.getCharset().name());
-                    props.add(prop);
+            try(final CloseableHttpResponse res = (CloseableHttpResponse)executeRequest(request)){
+                if (request.succeeded(res)) {
+                    final MultiStatus multiStatus = request.getResponseBodyAsMultiStatus(res);
+                    final MultiStatusResponse response = multiStatus.getResponses()[0];
+                    final DavPropertySet props = response.getProperties(HttpStatus.SC_OK);
+                    if (addEncoding) {
+                        final ContentType resContentType = ContentType.getOrDefault(res.getEntity());
+                        final DavProperty<String> prop = new DefaultDavProperty<>(RESPONSE_CHARSET,
+                                resContentType.getCharset().name());
+                        props.add(prop);
+                    }
+                    return props;
                 }
-                return props;
+                return new DavPropertySet();
             }
-            return new DavPropertySet();
         } catch (final FileSystemException fse) {
             throw fse;
         } catch (final Exception e) {


### PR DESCRIPTION
Instead of calling `((HttpRequestBase) request).releaseConnection()` directly after sending the request, encapsulate the HttpResponse in a try-with-resource block. This way, the connection is released after the HttpEntity is fully consumed.