### PR TITLE
VFS-844: Prevent that source files urlString is twice

### DIFF
--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/Webdav4FileObject.java
@@ -38,7 +38,6 @@ import org.apache.commons.vfs2.provider.GenericURLFileName;
 import org.apache.commons.vfs2.provider.http4.Http4FileObject;
 import org.apache.commons.vfs2.util.FileObjectUtils;
 import org.apache.commons.vfs2.util.MonitorOutputStream;
-import org.apache.commons.vfs2.util.URIUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -423,7 +422,7 @@ public class Webdav4FileObject extends Http4FileObject<Webdav4FileSystem> {
      */
     @Override
     protected void doRename(final FileObject newFile) throws Exception {
-        final String url = URIUtils.encodePath(toUrlString((GenericURLFileName) getName()));
+        final String url = toUrlString((GenericURLFileName) getName());
         final String dest = toUrlString((GenericURLFileName) newFile.getName(), false);
         final HttpMove request = new HttpMove(url, dest, false);
         setupRequest(request);

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderRenameTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/ProviderRenameTests.java
@@ -97,6 +97,23 @@ public class ProviderRenameTests extends AbstractProviderTestCase {
     }
 
     /**
+     * Tests create-delete-create-a-file sequence on the same file system.
+     */
+    @Test
+    public void testRenameFileWithSpaces() throws Exception {
+        final FileObject scratchFolder = createScratchFolder();
+
+        // Create direct child of the test folder
+        final FileObject file = scratchFolder.resolveFile("file space.txt");
+        assertFalse(file.exists());
+
+        final String content = createTestFile(file);
+
+        // Make sure we can move the new file to another file on the same file system
+        moveFile(scratchFolder, file, content);
+    }
+
+    /**
      * Moves a file from a child folder to a parent folder to test what happens when the original folder is now empty.
      *
      * See [VFS-298] FTP: Exception is thrown when renaming a file.


### PR DESCRIPTION
URIEncoded. Prevent that the urlString of a webdav-filename is twice URIEncoded when file is moved. Results in invalid filename if the filename contains spaces.