### PR TITLE
VFS-846: Resolve a FileName to correct FileType

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -925,9 +925,9 @@ public class DefaultFileSystemManager implements FileSystemManager {
             throw new FileSystemException("vfs.provider/invalid-descendent-name.error", name);
         }
 
-        //Reappend the removed trailing / in case of a FOLDER, so that the following calls to
-        //'provider.parseUri(realBase, fullPath)' can determine the correct FileType
-        //otherwise the resulting FileType is always fileType.FILE
+        // Reappend the removed trailing / in case of a FOLDER, so that the following calls to
+        // 'provider.parseUri(realBase, fullPath)' can determine the correct FileType
+        // otherwise the resulting FileType is always fileType.FILE
         final String trailingPathPart = (fileType == FileType.FOLDER) ? FileName.SEPARATOR : "";
 
         final String fullPath;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -925,12 +925,17 @@ public class DefaultFileSystemManager implements FileSystemManager {
             throw new FileSystemException("vfs.provider/invalid-descendent-name.error", name);
         }
 
+        //Reappend the removed trailing / in case of a FOLDER, so that the following calls to
+        //'provider.parseUri(realBase, fullPath)' can determine the correct FileType
+        //otherwise the resulting FileType is always fileType.FILE
+        final String trailingPathPart = (fileType == FileType.FOLDER) ? FileName.SEPARATOR : "";
+
         final String fullPath;
         if (scheme != null) {
-            fullPath = resolvedPath;
+            fullPath = resolvedPath + trailingPathPart;
         } else {
             scheme = realBase.getScheme();
-            fullPath = realBase.getRootURI() + resolvedPath;
+            fullPath = realBase.getRootURI() + resolvedPath + trailingPathPart;
         }
         final FileProvider provider = providers.get(scheme);
         if (provider != null) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -477,7 +477,13 @@ public final class UriParser {
             return fileType;
         }
 
-        if (path.charAt(path.length() - 1) != '/') {
+        // '/' or '.' or '..' or anyPath/..' or 'anyPath/.'  should always be a path
+        if (path.charAt(path.length() - 1) != '/'
+                && path.lastIndexOf("/..") != (path.length() - 3)
+                && path.lastIndexOf("/.") != (path.length() - 2)
+                && path.lastIndexOf("..") != 0
+                && path.lastIndexOf(".") != 0
+        ) {
             fileType = FileType.FILE;
         }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileSystemManagerTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileSystemManagerTest.java
@@ -169,7 +169,6 @@ public class DefaultFileSystemManagerTest {
     /**
      * If the path ends with one of '/' or '.' or '..' or anyPath/..' or 'anyPath/.' ,
      * the resulting FileName should be of FileType.FOLDER, else of FileType.FILE.
-     *
      */
     @Test
     public void testResolveFileNameType() {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.commons.vfs2.provider;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UriParserTest {
 
@@ -69,4 +70,27 @@ public class UriParserTest {
         assertEquals("/user:pass@host/some/path/some:file", buffer.toString());
     }
 
+    @Test
+    public void testTypeOfNormalizedPath() {
+        try {
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("/")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder(".")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("./")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("./Sub Folder/")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("./Sub Folder/.")));
+            assertEquals(FileType.FOLDER, UriParser.normalisePath(new StringBuilder("./Sub Folder/./")));
+
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("File.txt")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("/File.txt")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("./File.txt")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("./Sub Folder/File.txt")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("./Sub Folder/./File.txt")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("./Sub Folder/./File.")));
+            assertEquals(FileType.FILE, UriParser.normalisePath(new StringBuilder("./Sub Folder/./File..")));
+
+        } catch(FileSystemException e) {
+            fail(e);
+        }
+    }
 }


### PR DESCRIPTION
Fix that FileNames which are directories are resolved to FileType.FOLDER.

https://issues.apache.org/jira/browse/VFS-846
