### PR TITLE
[VFS-524] A URI with an IPv6 address can't be parsed out correctly

### DIFF
--- a/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/test/WebdavProviderTestCase.java
+++ b/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/test/WebdavProviderTestCase.java
@@ -41,7 +41,9 @@ import org.apache.commons.vfs2.AbstractProviderTestConfig;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.IPv6LocalConnectionTests;
 import org.apache.commons.vfs2.ProviderTestSuite;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.temp.TemporaryFileProvider;
 import org.apache.commons.vfs2.provider.webdav.WebdavFileProvider;
@@ -245,6 +247,18 @@ public class WebdavProviderTestCase extends AbstractProviderTestConfig {
             }
 
             @Override
+            protected void addBaseTests() throws Exception {
+                super.addBaseTests();
+
+                addTests(WebdavProviderTestCase.class);
+
+                // Webdav underlying implementation doesn't support link-local IPv6 url (but Webdav4 does)
+                // if (getSystemTestUriOverride() == null) {
+                //    addTests(IPv6LocalConnectionTests.class);
+                // }
+            }
+
+            @Override
             protected void tearDown() throws Exception {
                 tearDownClass();
                 super.tearDown();
@@ -317,4 +331,13 @@ public class WebdavProviderTestCase extends AbstractProviderTestConfig {
         manager.addProvider("tmp", new TemporaryFileProvider());
     }
 
+    @org.junit.Test
+    public void testResolveIPv6Url() throws Exception {
+        final String ipv6Url = "webdav://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt";
+
+        final FileObject fileObject = VFS.getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        assertEquals("webdav://user:pass@[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getFileSystem().getRootURI());
+        assertEquals("webdav://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt", fileObject.getName().getURI());
+    }
 }

--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/Webdav4ProviderTestCase.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/test/Webdav4ProviderTestCase.java
@@ -41,6 +41,7 @@ import org.apache.commons.vfs2.AbstractProviderTestConfig;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.IPv6LocalConnectionTests;
 import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.temp.TemporaryFileProvider;
@@ -256,6 +257,16 @@ public class Webdav4ProviderTestCase extends AbstractProviderTestConfig {
             }
 
             @Override
+            protected void addBaseTests() throws Exception {
+                super.addBaseTests();
+                addTests(Webdav4ProviderTestCase.class);
+
+                if (getSystemTestUriOverride() == null) {
+                    addTests(IPv6LocalConnectionTests.class);
+                }
+            }
+
+            @Override
             protected void tearDown() throws Exception {
                 tearDownClass();
                 super.tearDown();
@@ -326,4 +337,13 @@ public class Webdav4ProviderTestCase extends AbstractProviderTestConfig {
         manager.addProvider("tmp", new TemporaryFileProvider());
     }
 
+    @org.junit.Test
+    public void testResolveIPv6Url() throws Exception {
+        final String ipv6Url = "webdav4://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt";
+
+        final FileObject fileObject = VFS.getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        assertEquals("webdav4://user:pass@[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getFileSystem().getRootURI());
+        assertEquals("webdav4://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt", fileObject.getName().getURI());
+    }
 }

--- a/commons-vfs2-sandbox/src/test/java/org/apache/commons/vfs2/provider/smb/test/SmbProviderTestCase.java
+++ b/commons-vfs2-sandbox/src/test/java/org/apache/commons/vfs2/provider/smb/test/SmbProviderTestCase.java
@@ -17,14 +17,18 @@
 package org.apache.commons.vfs2.provider.smb.test;
 
 import junit.framework.Test;
+import junit.framework.TestSuite;
 
 import org.apache.commons.vfs2.AbstractProviderTestConfig;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.ProviderTestConfig;
 import org.apache.commons.vfs2.ProviderTestSuite;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.smb.SmbFileProvider;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests for the SMB file system.
@@ -37,7 +41,11 @@ public class SmbProviderTestCase extends AbstractProviderTestConfig implements P
         if (System.getProperty(TEST_URI) != null) {
             return new ProviderTestSuite(new SmbProviderTestCase());
         }
-        return notConfigured(SmbProviderTestCase.class);
+
+        // Cannot run IPv6LocalConnectionTests for smb, because there is no end-to-end test
+        // infrastructure implemented yet
+
+        return new TestSuite(SmbProviderTestCase.class);
     }
 
     /**
@@ -57,4 +65,15 @@ public class SmbProviderTestCase extends AbstractProviderTestConfig implements P
         return manager.resolveFile(uri);
     }
 
+    @org.junit.jupiter.api.Test
+    public void testResolveIPv6Url() throws Exception {
+        final String ipv6Url = "smb://user:pass@[fe80::1c42:dae:8370:aea6%en1]/share";
+
+        final FileObject fileObject = VFS.getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        Assertions.assertEquals(
+                "smb://user:pass@[fe80::1c42:dae:8370:aea6%en1]/share/", fileObject.getFileSystem().getRootURI());
+
+        Assertions.assertEquals("smb://user:pass@[fe80::1c42:dae:8370:aea6%en1]/share/", fileObject.getName().getURI());
+    }
 }

--- a/commons-vfs2-sandbox/src/test/java/org/apache/commons/vfs2/provider/smb/test/SmbProviderTestCase.java
+++ b/commons-vfs2-sandbox/src/test/java/org/apache/commons/vfs2/provider/smb/test/SmbProviderTestCase.java
@@ -16,9 +16,6 @@
  */
 package org.apache.commons.vfs2.provider.smb.test;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.apache.commons.vfs2.AbstractProviderTestConfig;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
@@ -29,6 +26,9 @@ import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.smb.SmbFileProvider;
 import org.junit.jupiter.api.Assertions;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 /**
  * Tests for the SMB file system.

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -163,11 +163,19 @@ public final class UriParser {
             throws FileSystemException {
         int index = offset;
         int count = length;
+        boolean ipv6Host = false;
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
-            if (ch != '%') {
+            if (ch == '[') {
+                ipv6Host = true;
+            }
+            if (ch == ']') {
+                ipv6Host = false;
+            }
+            if (ch != '%' || ipv6Host) {
                 continue;
             }
+
             if (count < 3) {
                 throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
                         buffer.substring(index, index + count));

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileObject.java
@@ -36,7 +36,6 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
-import org.apache.hc.client5.http.utils.URIUtils;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -94,7 +93,7 @@ public class Http5FileObject<FS extends Http5FileSystem> extends AbstractFileObj
         final FileSystemOptions fileSystemOptions = fileSystem.getFileSystemOptions();
         urlCharset = builder.getUrlCharset(fileSystemOptions);
         final String pathEncoded = ((GenericURLFileName) name).getPathQueryEncoded(getUrlCharset());
-        internalURI = URIUtils.resolve(fileSystem.getInternalBaseURI(), pathEncoded);
+        internalURI = fileSystem.getInternalBaseURI().resolve(pathEncoded);
     }
 
     @Override

--- a/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/resources/org/apache/commons/vfs2/Resources.properties
@@ -136,6 +136,7 @@ vfs.provider/missing-double-slashes.error=Expecting // to follow the scheme in U
 vfs.provider/missing-hostname.error=Hostname missing from URI "{0}".
 vfs.provider/missing-port.error=Port number is missing from URI "{0}".
 vfs.provider/missing-hostname-path-sep.error=Expecting / to follow the hostname in URI "{0}".
+vfs.provider/unterminated-ipv6-hostname.error=Unterminated IPv6 host name in URI "{0}".
 vfs.provider/invalid-descendent-name.error=Invalid descendent file name "{0}".
 vfs.provider/invalid-escape-sequence.error=Invalid URI escape sequence "{0}".
 vfs.provider/invalid-relative-path.error=Invalid relative file name.

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/IPv6LocalConnectionTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/IPv6LocalConnectionTests.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+
+public class IPv6LocalConnectionTests extends AbstractProviderTestCase {
+
+    private static final Log log = LogFactory.getLog(IPv6LocalConnectionTests.class);
+
+    @Override
+    protected void runTest() throws Throwable {
+        final List<String> localIPv6Addresses = getLocalIPv6Addresses();
+
+        if (localIPv6Addresses.isEmpty()) {
+            log.info("Local machine must have IPv6 address to run this test");
+            return;
+        }
+
+        super.runTest();
+    }
+
+    @Override
+    protected Capability[] getRequiredCapabilities() {
+        return new Capability[] {Capability.URI, Capability.READ_CONTENT};
+    }
+
+    @Test
+    public void testConnectIPv6UrlLocal() throws Exception {
+        final List<String> localIPv6Addresses = getLocalIPv6Addresses();
+
+        boolean connected = false;
+
+        for (String ipv6Address: localIPv6Addresses) {
+            final String ipv6Url = StringUtils.replace(
+                    this.getReadFolder().getURL().toString(), "localhost", "[" + ipv6Address + "]");
+
+            try {
+                final FileSystem fileSystem = getFileSystem();
+
+                final FileObject readFolderObject = getManager()
+                        .resolveFile(ipv6Url, setupConnectionTimeoutHints(fileSystem));
+
+                connected = connected || readFolderObject.resolveFile("file1.txt").getContent().getByteArray() != null;
+            } catch (FileSystemException e) {
+                // We don't care, if some of the discovered IPv6 addresses don't work.
+                // We just need a single one to work for testing the functionality end-to-end.
+                log.warn("Failed to connect to some of the local IPv6 network addresses", e);
+            }
+        }
+
+        assertTrue("None of the discovered local IPv6 network addresses has responded for connection", connected);
+    }
+
+    private static List<String> getLocalIPv6Addresses() throws SocketException {
+        final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        final List<String> result = new ArrayList<>();
+
+        for (NetworkInterface networkInterface : Collections.list(networkInterfaces)) {
+            if (!networkInterface.isUp() || networkInterface.isLoopback()
+                    // utun refers to VPN network interface, we don't expect this connection to work
+                    || networkInterface.getName().startsWith("utun")) {
+
+                continue;
+            }
+
+            for (InetAddress inetAddress : Collections.list(networkInterface.getInetAddresses())) {
+                if (inetAddress instanceof Inet6Address && !inetAddress.isLoopbackAddress() && !inetAddress.isMulticastAddress()) {
+                    result.add(inetAddress.getHostAddress());
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private FileSystemOptions setupConnectionTimeoutHints(FileSystem fileSystem) {
+        // Unfortunately there is no common way to set up timeouts for every protocol
+        // So, we use this hacky approach to make this class generic and formally independent of protocols implementations
+
+        FileSystemOptions result = (FileSystemOptions) fileSystem.getFileSystemOptions().clone();
+
+        Duration timeout = Duration.ofSeconds(5);
+
+        result.setOption(fileSystem.getClass(),
+                "org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.CONNECT_TIMEOUT", timeout);
+        result.setOption(fileSystem.getClass(),
+                "org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.TIMEOUT", timeout);
+
+        result.setOption(fileSystem.getClass(), "http.connection.timeout", timeout);
+        result.setOption(fileSystem.getClass(), "http.socket.timeout", timeout);
+
+        // This actually doesn't affect FtpFileProvider now, but it looks like an issue
+        // This would work, if FtpClientFactory call client.setConnectTimeout() with CONNECT_TIMEOUT value
+        result.setOption(fileSystem.getClass(),
+                "org.apache.commons.vfs2.provider.ftp.FtpFileSystemConfigBuilder.CONNECT_TIMEOUT", timeout);
+        result.setOption(fileSystem.getClass(),
+                "org.apache.commons.vfs2.provider.ftp.FtpFileSystemConfigBuilder.SO_TIMEOUT", timeout);
+
+        return result;
+    }
+
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -95,4 +95,8 @@ public class UriParserTest {
             fail(e);
         }
     }
+    @Test
+    public void testIPv6CheckUriEncoding() throws FileSystemException {
+        UriParser.checkUriEncoding("http://[fe80::14b5:1204:5410:64ca%en1]:8080");
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderIPv6TestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderIPv6TestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.ftp;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.IPv6LocalConnectionTests;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.provider.GenericFileName;
+import org.mockito.Mockito;
+
+import junit.framework.Test;
+
+public class FtpProviderIPv6TestCase extends FtpProviderTestCase {
+
+    public static Test suite() throws Exception {
+        return getSystemTestUriOverride() == null ?
+                suite(new FtpProviderIPv6TestCase(), FtpProviderIPv6TestCase.class, IPv6LocalConnectionTests.class) :
+                suite(new FtpProviderIPv6TestCase(), FtpProviderIPv6TestCase.class);
+    }
+
+    @Override
+    public void prepare(final DefaultFileSystemManager manager) throws Exception {
+        manager.addProvider("ftp", new MockedClientFtpFileProvider());
+    }
+
+    @org.junit.Test
+    public void testResolveIPv6Url() throws Exception {
+        final String ipv6Url = "ftp://[fe80::1c42:dae:8370:aea6%en1]/file.txt";
+
+        final FtpFileObject fileObject = (FtpFileObject) getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        assertEquals("ftp://[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getFileSystem().getRootURI());
+        assertEquals("file.txt", fileObject.getRelPath());
+    }
+
+    private static class MockedClientFtpFileProvider extends FtpFileProvider {
+        @Override
+        protected FileSystem doCreateFileSystem(FileName name, FileSystemOptions fileSystemOptions) {
+            final GenericFileName rootName = (GenericFileName) name;
+            return new FtpFileSystem(rootName, Mockito.mock(FtpClient.class), fileSystemOptions);
+        }
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderTestCase.java
@@ -68,7 +68,7 @@ public class FtpProviderTestCase extends AbstractProviderTestConfig {
         return socketPort;
     }
 
-    private static String getSystemTestUriOverride() {
+    protected static String getSystemTestUriOverride() {
         return System.getProperty(TEST_URI);
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http/HttpProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http/HttpProviderTestCase.java
@@ -81,7 +81,17 @@ public class HttpProviderTestCase extends AbstractProviderTestConfig {
             @Override
             protected void addBaseTests() throws Exception {
                 super.addBaseTests();
+
                 addTests(HttpProviderTestCase.class);
+
+                // HttpAsyncServer returns 400 on link local requests from Httpclient
+                // (e.g. Apache Web Server does the same https://bz.apache.org/bugzilla/show_bug.cgi?id=35122,
+                // but not every HTTP server does).
+                // Until this is addressed, local connection test won't work end-to-end
+
+                // if (getSystemTestUriOverride() == null) {
+                //    addTests(IPv6LocalConnectionTests.class);
+                // }
             }
 
             @Override
@@ -212,4 +222,14 @@ public class HttpProviderTestCase extends AbstractProviderTestConfig {
         testResolveFolderSlash(connectionUri + "/read-tests/", true);
     }
 
+    @Test
+    public void testResolveIPv6Url() throws FileSystemException {
+        final String ipv6Url = "http://[fe80::1c42:dae:8370:aea6%en1]/file.txt";
+
+        @SuppressWarnings("rawtypes")
+        final FileObject fileObject = VFS.getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        assertEquals("http://[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getFileSystem().getRootURI());
+        assertEquals("http://[fe80::1c42:dae:8370:aea6%en1]/file.txt", fileObject.getName().getURI());
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5ProviderTestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/http5/Http5ProviderTestCase.java
@@ -80,7 +80,17 @@ public class Http5ProviderTestCase extends AbstractProviderTestConfig {
             @Override
             protected void addBaseTests() throws Exception {
                 super.addBaseTests();
+
                 addTests(Http5ProviderTestCase.class);
+
+                // HttpAsyncServer returns 400 on link local requests from Httpclient
+                // (e.g. Apache Web Server does the same https://bz.apache.org/bugzilla/show_bug.cgi?id=35122,
+                // but not every HTTP server does).
+                // Until this is addressed, local connection test won't work end-to-end
+
+                // if (getSystemTestUriOverride() == null) {
+                //    addTests(IPv6LocalConnectionTests.class);
+                // }
             }
 
             @Override
@@ -210,4 +220,14 @@ public class Http5ProviderTestCase extends AbstractProviderTestConfig {
         testResolveFolderSlash(connectionUri + "/read-tests/", true);
     }
 
+    @Test
+    public void testResolveIPv6Url() throws FileSystemException {
+        final String ipv6Url = "http5://[fe80::1c42:dae:8370:aea6%en1]";
+
+        @SuppressWarnings("rawtypes")
+        final Http5FileObject fileObject = (Http5FileObject)
+                VFS.getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+        assertEquals("http://[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getInternalURI().toString());
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpProviderIPv6TestCase.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/sftp/SftpProviderIPv6TestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.sftp;
+
+import java.io.IOException;
+
+import org.apache.commons.io.input.NullInputStream;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.IPv6LocalConnectionTests;
+import org.apache.commons.vfs2.provider.GenericFileName;
+import org.mockito.Mockito;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import junit.framework.Test;
+
+public class SftpProviderIPv6TestCase extends AbstractSftpProviderTestCase {
+
+    public static Test suite() throws Exception {
+        return new SftpProviderTestSuite(new SftpProviderIPv6TestCase()) {
+            @Override
+            protected void addBaseTests() throws Exception {
+                addTests(SftpProviderIPv6TestCase.class);
+
+                if (getSystemTestUriOverride() == null) {
+                    addTests(IPv6LocalConnectionTests.class);
+                }
+            }
+        };
+    }
+
+    @Override
+    protected boolean isExecChannelClosed() {
+        return false;
+    }
+
+    @org.junit.Test
+    public void testResolveIPv6Url() throws Exception {
+        try {
+            // We only want to use mocked client for this test, not for the test class initialization
+            getManager().removeProvider("sftp");
+            getManager().addProvider("sftp", new MockedClientSftpFileProvider());
+
+            final String ipv6Url = "sftp://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt";
+
+            final FileObject fileObject = getManager().resolveFile(ipv6Url, new FileSystemOptions());
+
+            assertEquals("sftp://user:pass@[fe80::1c42:dae:8370:aea6%en1]/", fileObject.getFileSystem().getRootURI());
+            assertEquals("sftp://user:pass@[fe80::1c42:dae:8370:aea6%en1]/file.txt", fileObject.getName().getURI());
+        } finally {
+            getManager().removeProvider("sftp");
+            getManager().addProvider("sftp", new SftpFileProvider());
+        }
+    }
+
+    private static class MockedClientSftpFileProvider extends SftpFileProvider {
+        @Override
+        protected FileSystem doCreateFileSystem(FileName name, FileSystemOptions fileSystemOptions) {
+            final GenericFileName rootName = (GenericFileName) name;
+
+            final Session sessionMock = Mockito.mock(Session.class);
+            final ChannelExec channelExecMock = Mockito.mock(ChannelExec.class);
+
+            Mockito.when(sessionMock.isConnected()).thenReturn(true);
+
+            try {
+                Mockito.when(sessionMock.openChannel(Mockito.anyString())).thenReturn(channelExecMock);
+            } catch (JSchException e) {
+                throw new AssertionError("Should never happen", e);
+            }
+
+            Mockito.when(channelExecMock.isClosed()).thenReturn(true);
+
+            try {
+                Mockito.when(channelExecMock.getInputStream()).thenReturn(new NullInputStream());
+            } catch (IOException e) {
+                throw new AssertionError("Should never happen", e);
+            }
+
+            return new SftpFileSystem(rootName, sessionMock, fileSystemOptions);
+        }
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
@@ -55,6 +55,10 @@ public class GenericFileNameTest {
         // Missing absolute path
         testBadlyFormedUri("ftp://host:90a", "vfs.provider/missing-hostname-path-sep.error");
         testBadlyFormedUri("ftp://host?a", "vfs.provider/missing-hostname-path-sep.error");
+
+        // Improperly accepted malformed uris
+        // testBadlyFormedUri("ftp://host[a/file", "malformed uri");
+        // testBadlyFormedUri("ftp://host]a/file", "malformed uri");
     }
 
     /**
@@ -144,6 +148,40 @@ public class GenericFileNameTest {
         // See also https://issues.apache.org/jira/browse/VFS-810
         assertEquals("ftp://user::%40@hostname/", name.getRootURI());
         assertEquals("ftp://user::%40@hostname/", name.getURI());
+
+        // Hostname with unreserved uri symbols "-", ".", "_", "~"
+        // https://datatracker.ietf.org/doc/html/rfc3986#page-49
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0~p1_p2-p3.p4/file");
+        assertEquals("ftp", name.getScheme());
+        assertNull(name.getUserName());
+        assertNull(name.getPassword());
+        assertEquals("p0~p1_p2-p3.p4", name.getHostName());
+        assertEquals(21, name.getPort());
+        assertEquals("/file", name.getPath());
+        assertEquals("ftp://p0~p1_p2-p3.p4/", name.getRootURI());
+        assertEquals("ftp://p0~p1_p2-p3.p4/file", name.getURI());
+
+        // Hostname with sub-delim uri symbols that are currently accepted with the hostname parser
+        // https://datatracker.ietf.org/doc/html/rfc3986#page-49
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0!p1'p2(p3)*p4/file");
+        assertEquals("ftp", name.getScheme());
+        assertNull(name.getUserName());
+        assertNull(name.getPassword());
+        assertEquals("p0!p1'p2(p3)*p4", name.getHostName());
+        assertEquals(21, name.getPort());
+        assertEquals("/file", name.getPath());
+        assertEquals("ftp://p0!p1'p2(p3)*p4/", name.getRootURI());
+        assertEquals("ftp://p0!p1'p2(p3)*p4/file", name.getURI());
+
+        // Hostnames with sub-delim uri symbols that are currently not accepted with the hostname parser
+        // (which looks wrong)
+        // https://datatracker.ietf.org/doc/html/rfc3986#page-49
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0$p1/file");
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0&p1/file");
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0+p1/file");
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0,p1/file");
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0;p1/file");
+        // name = (GenericFileName) urlParser.parseUri(null, null, "ftp://p0=p1/file");
     }
 
     @Test

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.GenericURLFileNameParser;
 import org.apache.commons.vfs2.provider.URLFileNameParser;
 import org.junit.jupiter.api.Test;
 
@@ -145,4 +146,180 @@ public class GenericFileNameTest {
         assertEquals("ftp://user::%40@hostname/", name.getURI());
     }
 
+    @Test
+    public void testParseIPv6Uri() throws Exception {
+        GenericURLFileNameParser urlParser = new GenericURLFileNameParser(21);
+
+        // basic case
+        GenericFileName name = (GenericFileName) urlParser.parseUri(
+                null, null, "ftp://[fe80::3dd0:7f8e:57b7:34d5]:2222/test");
+        assertEquals("[fe80::3dd0:7f8e:57b7:34d5]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("/test", name.getPath());
+        assertEquals("ftp://[fe80::3dd0:7f8e:57b7:34d5]:2222/", name.getRootURI());
+        assertEquals("ftp://[fe80::3dd0:7f8e:57b7:34d5]:2222/test", name.getURI());
+
+        // full uri case
+        name = (GenericFileName) urlParser.parseUri(
+                null, null, "http://user:password@[fe80::3dd0:7f8e:57b7:34d5]:2222/test?param1=value1&param2=value2#fragment");
+        assertEquals("[fe80::3dd0:7f8e:57b7:34d5]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("/test", name.getPath());
+        assertEquals("http://user:password@[fe80::3dd0:7f8e:57b7:34d5]:2222/", name.getRootURI());
+        assertEquals(
+                "http://user:password@[fe80::3dd0:7f8e:57b7:34d5]:2222/test?param1=value1&param2=value2#fragment",
+                name.getURI());
+
+        // no trailing zeroes case
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[2001:658:22a:cafe::]:2222/test");
+        assertEquals("[2001:658:22a:cafe::]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[2001:658:22a:cafe::]:2222/test", name.getURI());
+
+        // the loopback address
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[::1]:2222/test");
+        assertEquals("[::1]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[::1]:2222/test", name.getURI());
+
+        // the unspecified address
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[::]:2222/test");
+        assertEquals("[::]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[::]:2222/test", name.getURI());
+
+        // form for a mixed environment of IPv4 and IPv6
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[0:0:0:0:0:0:13.1.68.3]:2222/test");
+        assertEquals("[0:0:0:0:0:0:13.1.68.3]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[0:0:0:0:0:0:13.1.68.3]:2222/test", name.getURI());
+
+        // compressed form for a mixed environment of IPv4 and IPv6
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[::13.1.68.3]:2222/test");
+        assertEquals("[::13.1.68.3]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[::13.1.68.3]:2222/test", name.getURI());
+
+        // compressed form for a mixed environment of IPv4 and IPv6
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[::FFFF:129.144.52.38]:2222/test");
+        assertEquals("[::ffff:129.144.52.38]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[::ffff:129.144.52.38]:2222/test", name.getURI());
+
+        // a multicast address
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[FF01::101]:2222/test");
+        assertEquals("[ff01::101]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[ff01::101]:2222/test", name.getURI());
+
+        // url without path
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[FF01::101]:2222");
+        assertEquals("[ff01::101]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[ff01::101]:2222/", name.getURI());
+
+        // url without path and port
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[FF01::101]");
+        assertEquals("[ff01::101]", name.getHostName());
+        assertEquals(21, name.getPort());
+        assertEquals("ftp://[ff01::101]/", name.getURI());
+
+        // address with scopeId
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[fe80::8b2:d61e:e5c:b333%15]");
+        assertEquals("[fe80::8b2:d61e:e5c:b333%15]", name.getHostName());
+        assertEquals(21, name.getPort());
+        assertEquals("ftp://[fe80::8b2:d61e:e5c:b333%15]/", name.getURI());
+
+        // address with scopeId and escaped characters in the path
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[fe80::8b2:d61e:e5c:b333%15]/tests%3A+test+1");
+        assertEquals("[fe80::8b2:d61e:e5c:b333%15]", name.getHostName());
+        assertEquals(21, name.getPort());
+        assertEquals("ftp://[fe80::8b2:d61e:e5c:b333%15]/tests:+test+1", name.getURI());
+    }
+
+    @Test
+    public void testIPv6BadlyFormedUri() {
+        // address with opening bracket only
+        testBadlyFormedUri("ftp://[", "vfs.provider/unterminated-ipv6-hostname.error");
+
+        // address with closing bracket only (ftp://]) actually currently parses ok, but it's not considered as IPv6 case by parser
+
+        // address with unterminated host name
+        testBadlyFormedUri("ftp://[fe80::8b2:d61e:e5c:b333", "vfs.provider/unterminated-ipv6-hostname.error");
+
+        // address without opening bracket (first ":" considered as port number separator in this case)
+        testBadlyFormedUri("ftp://fe80::8b2:d61e:e5c:b333]", "vfs.provider/missing-port.error");
+
+        // empty address in brackets
+        testBadlyFormedUri("ftp://[]", "vfs.provider/missing-hostname.error");
+
+        // double square brackets
+        // (first "]" considered as terminating bracket, path separator is expected instead of the second "]")
+        testBadlyFormedUri("ftp://[[fe80::8b2:d61e:e5c:b333]]", "vfs.provider/missing-hostname-path-sep.error");
+
+        // two empty strings in brackets
+        testBadlyFormedUri("ftp://[][]", "vfs.provider/missing-hostname.error");
+
+        // two non-empty strings in brackets
+        testBadlyFormedUri("ftp://[fe80::8b2:d61e:e5c:b333][fe80::8b2:d61e:e5c:b333]", "vfs.provider/missing-hostname-path-sep.error");
+    }
+
+    @Test
+    public void testParseIPv6InvalidHostsTolerance() throws Exception {
+        // We don't strictly validate IPv6 host name, if it can be parsed out from URI
+        // Assuming, it'll just fail on connection stage
+
+        GenericURLFileNameParser urlParser = new GenericURLFileNameParser(21);
+
+        // too few segments
+        GenericFileName name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[1:2e]:2222/test");
+        assertEquals("[1:2e]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[1:2e]:2222/test", name.getURI());
+
+        // IPv4 address in square brackets
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[192.168.1.1]:2222/test");
+        assertEquals("[192.168.1.1]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[192.168.1.1]:2222/test", name.getURI());
+
+        // too many segments
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[::7:6:5:4:3:2:1:0]:2222/test");
+        assertEquals("[::7:6:5:4:3:2:1:0]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[::7:6:5:4:3:2:1:0]:2222/test", name.getURI());
+
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[3ffe:0:0:0:0:0:0:0:1]:2222/test");
+        assertEquals("[3ffe:0:0:0:0:0:0:0:1]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[3ffe:0:0:0:0:0:0:0:1]:2222/test", name.getURI());
+
+        // segment exceeds 16 bits
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[3ffe::10000]:2222/test");
+        assertEquals("[3ffe::10000]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[3ffe::10000]:2222/test", name.getURI());
+
+        // whitespace host
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[ ]:2222/test");
+        assertEquals("[ ]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[ ]:2222/test", name.getURI());
+
+        // just some invalid sequences
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[:]:2222/test");
+        assertEquals("[:]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[:]:2222/test", name.getURI());
+
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[:::]:2222/test");
+        assertEquals("[:::]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[:::]:2222/test", name.getURI());
+
+        name = (GenericFileName) urlParser.parseUri(null, null, "ftp://[xyz]:2222/test");
+        assertEquals("[xyz]", name.getHostName());
+        assertEquals(2222, name.getPort());
+        assertEquals("ftp://[xyz]:2222/test", name.getURI());
+    }
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTest.java
@@ -56,7 +56,7 @@ public class GenericFileNameTest {
         testBadlyFormedUri("ftp://host:90a", "vfs.provider/missing-hostname-path-sep.error");
         testBadlyFormedUri("ftp://host?a", "vfs.provider/missing-hostname-path-sep.error");
 
-        // Improperly accepted malformed uris
+        // TODO Improperly accepted malformed uris
         // testBadlyFormedUri("ftp://host[a/file", "malformed uri");
         // testBadlyFormedUri("ftp://host]a/file", "malformed uri");
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/VFS-524

The fix is based on the one, suggested in the Jira ticket, but also includes some corner cases covered and a number of additional unit tests, also tested end-to-end.