### PR TITLE
[VFS-853] Fix FileListener on DelegateFileObject.

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/WeakRefFileListener.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/util/WeakRefFileListener.java
@@ -32,13 +32,24 @@ import org.apache.commons.vfs2.FileSystem;
 public class WeakRefFileListener implements FileListener {
 
     /**
-     * Installs the {@code listener} at the given {@code file}.
+     * Install the {@code listener} at the given {@code file}.
+     * <p>
+     * This installs a wrapper with a weak reference, so the listener can
+     * be collected. The reference to the listener is removed when the
+     * first event can't be delivered.
+     * <p>
+     * Warning: you cannot remove the listener with
+     * {@code fs.removeListener(file, listener)} as you do'nt have the wrapper
+     * instance at hand.
+     * <p>
+     * Method is used by {@link org.apache.commons.vfs2.provider.DelegateFileObject},
+     * as used for {@link org.apache.commons.vfs2.impl.VirtualFileSystem}.
      *
      * @param file The FileObject to listen on.
      * @param listener The FileListener
      */
     public static void installListener(final FileObject file, final FileListener listener) {
-        file.getFileSystem().addListener(file, new WeakRefFileListener(file, new WeakRefFileListener(file, listener)));
+        file.getFileSystem().addListener(file, new WeakRefFileListener(file, listener));
     }
 
     private final FileSystem fs;

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -47,6 +47,9 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="2.10.0" date="YYYY-MM-DD" description="Maintenance release. Requires Java 8 or above.">
       <!-- FIX -->
+      <action type="fix" issue="VFS-853" dev="ecki" due-to="Bernd Eckenfels">
+        Double wrapped weak FileListener can lose change notification with DelegateFileObject.
+      </action>
       <action type="fix" dev="ggregory" due-to="Seth Falco">
         Replace package.html with package-info.java #206. 
       </action>


### PR DESCRIPTION
This adds a new test JunctionTests#testEvent() which fails when the fix is not present.