### PR TITLE
UriParser fix and performance improvements

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -70,8 +70,8 @@ public final class UriParser {
             if (cursor + 2 >= end) {
                 return false;
             }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals("%2e") || sub.equals("%2E")) {
+            if (path.charAt(cursor) == '%' && path.charAt(cursor + 1) == '2' &&
+                    (path.charAt(cursor + 2) == 'E' || path.charAt(cursor + 2) == 'e')) {
                 cursor += 3;
                 return true;
             }
@@ -89,8 +89,7 @@ public final class UriParser {
                 cursor++;
                 return true;
             }
-            final String sub = path.substring(cursor + 1, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
+            if (isCursorAtUrlEncodedSlash()) {
                 return false;
             }
             cursor++;
@@ -115,19 +114,19 @@ public final class UriParser {
             if (cursor + 2 >= end) {
                 return false;
             }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_LC) || sub.equals(URLENCODED_SLASH_UC)) {
-                cursor += 3;
+            if (isCursorAtUrlEncodedSlash()) {
+                path.setCharAt(cursor, SEPARATOR_CHAR);
+                path.delete(cursor + 1, cursor + 3);
+                end -= 2;
+                cursor++;
                 return true;
             }
             return false;
         }
 
-        private void readToNextSeparator() {
-            boolean reading = true;
-            while (reading) {
-                reading = readNonSeparator();
-            }
+        private boolean isCursorAtUrlEncodedSlash() {
+            return path.charAt(cursor) == '%' && path.charAt(cursor + 1) == '2' &&
+                    (path.charAt(cursor + 2) == 'F' || path.charAt(cursor + 2) == 'f');
         }
 
         private void removePreviousElement(final int to) throws FileSystemException {
@@ -182,7 +181,7 @@ public final class UriParser {
                         }
                     }
                 } else {
-                    readToNextSeparator();
+                    readNonSeparators();
                     lastSeparator = cursor;
                     readSeparator();
                 }
@@ -208,9 +207,6 @@ public final class UriParser {
     private static final int BITS_IN_HALF_BYTE = 4;
 
     private static final char LOW_MASK = 0x0F;
-    private static final String URLENCODED_SLASH_LC = "%2f";
-
-    private static final String URLENCODED_SLASH_UC = "%2F";
 
     /**
      * Encodes and appends a string to a StringBuilder.
@@ -670,8 +666,8 @@ public final class UriParser {
                 path.delete(maxlen - 1, maxlen);
             }
             if (maxlen > 3) {
-                final String sub = path.substring(maxlen - 3);
-                if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
+                if (path.charAt(maxlen - 3) == '%' && path.charAt(maxlen - 2) == '2' &&
+                    (path.charAt(maxlen - 1) == 'F' || path.charAt(maxlen - 1) == 'f')) {
                     path.delete(maxlen - 3, maxlen);
                 }
             }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -665,11 +665,10 @@ public final class UriParser {
             if (maxlen > 1 && path.charAt(maxlen - 1) == SEPARATOR_CHAR) {
                 path.delete(maxlen - 1, maxlen);
             }
-            if (maxlen > 3) {
-                if (path.charAt(maxlen - 3) == '%' && path.charAt(maxlen - 2) == '2' &&
+            if (maxlen > 3 &&
+                    path.charAt(maxlen - 3) == '%' && path.charAt(maxlen - 2) == '2' &&
                     (path.charAt(maxlen - 1) == 'F' || path.charAt(maxlen - 1) == 'f')) {
-                    path.delete(maxlen - 3, maxlen);
-                }
+                path.delete(maxlen - 3, maxlen);
             }
         }
 


### PR DESCRIPTION
I've noticed using JFR for performance profiling that `AbstractFileObject.getChildren()` was spending most of the time in `StringBuilder.substring()` done in the `UriParser.PathNormalizer` class.
See attached flamegraphs.
![profiling-UriParser-crop](https://github.com/apache/commons-vfs/assets/318821/80c9b0aa-6337-4355-ba01-dd2ad67befbd)

Looking at the code, I first notice that the substring that was using the most of time was incorrect as it was producing a String of length 2 and we were comparing it with a String of length 3.
I've added a private method `isCursorAtUrlEncodedSlash()` to perform the test for %2f using `charAt` instead of `substring` and at the same time fix the invalid comparaison.

After fixing the test in '`readNonSeparators()`', a unit test failed:
`NamingTests` -> `assertSameName(path, name, "foo%2f..%2fa", scope);`
The reason was before the fix the resolved path was '/Java/libraries/commons-vfs/commons-vfs2/target/test-classes/test-data/read-tests/foo%2f..%2fa'
After the fix the resolved path is '/Java/libraries/commons-vfs/commons-vfs2/target/test-classes/test-data/read-tests%2fa'
`AbstractFileName.checkName` (with scope child) wasn't failing first as `path.charAt(baseLen)` was '/' (the '/' before foo)
then it was failing as the separator at baseLen was %2f and not '/'.
So I've changed the `UriParser.PathNormalizer.readSeparator()` to also normalize the '%2f' to '/'. This fixes the unit tests.

At the same time, I've replaced the other not needed `StringBuilder.substring` of `UriParser` with `StringBuilder.charAt` as profiling data (See attached flamegraph) was showing performance costs in `readDot`.
![profiling-UriParser2-crop](https://github.com/apache/commons-vfs/assets/318821/cb44ca9a-a5c6-4f28-ba1c-08433324093f)

I've also removed the `readToNextSeparator()` as it was the exact same code as `readNonSeparators()`