### PR TITLE
Improve performance of UriParser normalize

### DIFF
--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -140,6 +140,12 @@
       <artifactId>httpcore-nio</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- JMH Performance tests -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -359,21 +365,13 @@
       <properties>
         <skipTests>true</skipTests>
         <benchmark>org.apache</benchmark>
-        <jmh.version>1.37</jmh.version>
       </properties>
 
       <dependencies>
         <dependency>
           <groupId>org.openjdk.jmh</groupId>
-          <artifactId>jmh-core</artifactId>
-          <version>${jmh.version}</version>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>org.openjdk.jmh</groupId>
           <artifactId>jmh-generator-annprocess</artifactId>
-          <version>${jmh.version}</version>
+          <version>1.37</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -352,6 +352,75 @@
         </plugins>
       </build>
     </profile>
+    <!-- Profile to build and run the benchmarks. Use 'mvn test -Pbenchmark', and add '-Dbenchmark=foo' to run only the foo benchmark -->
+    <profile>
+      <id>benchmark</id>
+
+      <properties>
+        <skipTests>true</skipTests>
+        <benchmark>org.apache</benchmark>
+        <jmh.version>1.37</jmh.version>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-core</artifactId>
+          <version>${jmh.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-generator-annprocess</artifactId>
+          <version>${jmh.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <!-- Enable the compilation of the benchmarks -->
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${commons.compiler.version}</version>
+            <configuration combine.self="override">
+              <testIncludes>
+                <testInclude>**/*</testInclude>
+              </testIncludes>
+            </configuration>
+          </plugin>
+          <!-- Hook the benchmarks to the test phase -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>benchmark</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <classpathScope>test</classpathScope>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath />
+                    <argument>org.openjdk.jmh.Main</argument>
+                    <argument>-rf</argument>
+                    <argument>json</argument>
+                    <argument>-rff</argument>
+                    <argument>target/jmh-result.json</argument>
+                    <argument>${benchmark}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -70,8 +70,8 @@ public final class UriParser {
             if (cursor + 2 >= end) {
                 return false;
             }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals("%2e") || sub.equals("%2E")) {
+            if (path.charAt(cursor) == '%' && path.charAt(cursor + 1) == '2' &&
+                    (path.charAt(cursor + 2) == 'E' || path.charAt(cursor + 2) == 'e')) {
                 cursor += 3;
                 return true;
             }
@@ -89,8 +89,7 @@ public final class UriParser {
                 cursor++;
                 return true;
             }
-            final String sub = path.substring(cursor + 1, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
+            if (isCursorAtUrlEncodedSlash()) {
                 return false;
             }
             cursor++;
@@ -115,8 +114,7 @@ public final class UriParser {
             if (cursor + 2 >= end) {
                 return false;
             }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_LC) || sub.equals(URLENCODED_SLASH_UC)) {
+            if (isCursorAtUrlEncodedSlash()) {
                 cursor += 3;
                 return true;
             }
@@ -128,6 +126,11 @@ public final class UriParser {
             while (reading) {
                 reading = readNonSeparator();
             }
+        }
+
+        private boolean isCursorAtUrlEncodedSlash() {
+            return path.charAt(cursor) == '%' && path.charAt(cursor + 1) == '2' &&
+                    (path.charAt(cursor + 2) == 'F' || path.charAt(cursor + 2) == 'f');
         }
 
         private void removePreviousElement(final int to) throws FileSystemException {
@@ -669,11 +672,10 @@ public final class UriParser {
             if (maxlen > 1 && path.charAt(maxlen - 1) == SEPARATOR_CHAR) {
                 path.delete(maxlen - 1, maxlen);
             }
-            if (maxlen > 3) {
-                final String sub = path.substring(maxlen - 3);
-                if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
-                    path.delete(maxlen - 3, maxlen);
-                }
+            if (maxlen > 3 &&
+                    path.charAt(maxlen - 3) == '%' && path.charAt(maxlen - 2) == '2' &&
+                    (path.charAt(maxlen - 1) == 'F' || path.charAt(maxlen - 1) == 'f')) {
+                path.delete(maxlen - 3, maxlen);
             }
         }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -211,9 +211,6 @@ public final class UriParser {
     private static final int BITS_IN_HALF_BYTE = 4;
 
     private static final char LOW_MASK = 0x0F;
-    private static final String URLENCODED_SLASH_LC = "%2f";
-
-    private static final String URLENCODED_SLASH_UC = "%2F";
 
     /**
      * Encodes and appends a string to a StringBuilder.

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserBenchmark.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserBenchmark.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+public class UriParserBenchmark {
+
+    private static final String PATH_TO_NORMALIZE = "file:///this/../is/a%2flong%2Fpath/./for testing/normlisePath%2fmethod.txt";
+
+    @Benchmark
+    public void normalisePath() throws FileSystemException {
+        StringBuilder path = new StringBuilder(PATH_TO_NORMALIZE);
+        UriParser.normalisePath(path);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -684,6 +684,13 @@
         <artifactId>jsr311-api</artifactId>
         <version>1.1.1</version>
       </dependency>
+      <!-- JMH Performance tests -->
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>1.37</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Here is a performance improvement of `UriParser.normalise()`.
I've replaced the slow `StringBuilder.substring()` with `StringBuilder.charAt()`. I think that `StringBuilder.subSequence()` with `CharSequence.compare()` could show similar performance improvements. Let me know if you want me to test this way.

Note that I would advise to first merge https://github.com/apache/commons-vfs/pull/543/files that fixes a bug in the test of %2f. I didn't want to reintroduce the bug with this merge request so the bug is also fixed in here. This MR may have a merge conflict with https://github.com/apache/commons-vfs/pull/543/ as it touches the same part of the code. If you want I can resolve it once https://github.com/apache/commons-vfs/pull/543/ is merged.

On my machine (Desktop from 2016) I have a 3x throughput.

JMH
Benchmark                      Mode  Cnt       Score       Error  Units
UriParserBenchmark.normalise  thrpt   50  994208,463  11590,176  ops/s

After refactoring
Benchmark                      Mode  Cnt        Score       Error  Units
UriParserBenchmark.normalise  thrpt   25  2940553,554  47617,743  ops/s

JFR/JMC flamegraphs
![profiling-UriParser-crop](https://github.com/apache/commons-vfs/assets/318821/aca64859-e509-4280-859f-92a8e6b32fde)

![profiling-UriParser2-crop](https://github.com/apache/commons-vfs/assets/318821/79cd4ccc-c7a2-4aca-8df9-50a067dfcd59)
