### PR TITLE
Simplify UriParser

### DIFF
--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -140,6 +140,12 @@
       <artifactId>httpcore-nio</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- JMH Performance tests -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -348,6 +354,66 @@
                 <exclude>**/*Tests.java</exclude>
               </excludes>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- Profile to build and run the benchmarks. Use 'mvn test -Pbenchmark', and add '-Dbenchmark=foo' to run only the foo benchmark -->
+    <profile>
+      <id>benchmark</id>
+
+      <properties>
+        <skipTests>true</skipTests>
+        <benchmark>org.apache</benchmark>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-generator-annprocess</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <!-- Enable the compilation of the benchmarks -->
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${commons.compiler.version}</version>
+            <configuration combine.self="override">
+              <testIncludes>
+                <testInclude>**/*</testInclude>
+              </testIncludes>
+            </configuration>
+          </plugin>
+          <!-- Hook the benchmarks to the test phase -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>benchmark</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <classpathScope>test</classpathScope>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath />
+                    <argument>org.openjdk.jmh.Main</argument>
+                    <argument>-rf</argument>
+                    <argument>json</argument>
+                    <argument>-rff</argument>
+                    <argument>target/jmh-result.json</argument>
+                    <argument>${benchmark}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -29,168 +29,6 @@ import org.apache.commons.vfs2.VFS;
  */
 public final class UriParser {
 
-    private static class PathNormalizer {
-        private final StringBuilder path;
-
-        private int cursor;
-        private int lastSeparator;
-        private int end;
-
-        PathNormalizer(final StringBuilder path) {
-            this.path = path;
-            end = path.length();
-        }
-
-        private boolean consumeSeparator() {
-            final int from = cursor;
-            if (readSeparator()) {
-                path.delete(from, cursor);
-                cursor = from;
-                end = path.length();
-                return true;
-            }
-            return false;
-        }
-
-        private void consumeSeparators() {
-            boolean consuming = true;
-            while (consuming) {
-                consuming = consumeSeparator();
-            }
-        }
-
-        private boolean readDot() {
-            if (cursor == end) {
-                return false;
-            }
-            if (path.charAt(cursor) == '.') {
-                cursor++;
-                return true;
-            }
-            if (cursor + 2 >= end) {
-                return false;
-            }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals("%2e") || sub.equals("%2E")) {
-                cursor += 3;
-                return true;
-            }
-            return false;
-        }
-
-        private boolean readNonSeparator() {
-            if (cursor == end) {
-                return false;
-            }
-            if (path.charAt(cursor) == SEPARATOR_CHAR) {
-                return false;
-            }
-            if (cursor + 2 >= end) {
-                cursor++;
-                return true;
-            }
-            final String sub = path.substring(cursor + 1, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
-                return false;
-            }
-            cursor++;
-            return true;
-        }
-
-        private void readNonSeparators() {
-            boolean reading = true;
-            while (reading) {
-                reading = readNonSeparator();
-            }
-        }
-
-        private boolean readSeparator() {
-            if (cursor == end) {
-                return false;
-            }
-            if (path.charAt(cursor) == SEPARATOR_CHAR) {
-                cursor++;
-                return true;
-            }
-            if (cursor + 2 >= end) {
-                return false;
-            }
-            final String sub = path.substring(cursor, cursor + 3);
-            if (sub.equals(URLENCODED_SLASH_LC) || sub.equals(URLENCODED_SLASH_UC)) {
-                cursor += 3;
-                return true;
-            }
-            return false;
-        }
-
-        private void readToNextSeparator() {
-            boolean reading = true;
-            while (reading) {
-                reading = readNonSeparator();
-            }
-        }
-
-        private void removePreviousElement(final int to) throws FileSystemException {
-            if (lastSeparator == 0) {
-                // Previous element is missing
-                throw new FileSystemException("vfs.provider/invalid-relative-path.error");
-            }
-            cursor = lastSeparator - 1;
-            while (readNonSeparator()) {
-                cursor -= 2;
-                if (cursor < 0) {
-                    // Previous element is the first element
-                    cursor = 0;
-                    break;
-                }
-            }
-            path.delete(cursor, to);
-            lastSeparator = cursor;
-            end = path.length();
-            readSeparator();
-        }
-
-        void run() throws FileSystemException {
-            lastSeparator = cursor;
-            readSeparator();
-            while (cursor < end) {
-                consumeSeparators();
-                if (readDot()) {
-                    if (readDot()) {
-                        final int beforeNextSeparator = cursor;
-                        if (readSeparator() || cursor == end) {
-                            // '/../'
-                            removePreviousElement(beforeNextSeparator);
-                        } else {
-                            // '/..other'
-                            readNonSeparators();
-                            lastSeparator = cursor;
-                            readSeparator();
-                        }
-                    } else {
-                        final int beforeNextSeparator = cursor;
-                        if (readSeparator() || cursor == end) {
-                            // '/./'
-                            path.delete(lastSeparator, beforeNextSeparator);
-                            cursor = lastSeparator + cursor - beforeNextSeparator;
-                            end = path.length();
-                        } else {
-                            // '/.other'
-                            readNonSeparators();
-                            lastSeparator = cursor;
-                            readSeparator();
-                        }
-                    }
-                } else {
-                    readToNextSeparator();
-                    lastSeparator = cursor;
-                    readSeparator();
-                }
-            }
-        }
-
-    }
-
     /**
      * The set of valid separators. These are all converted to the normalized one. Does <em>not</em> contain the
      * normalized separator
@@ -208,9 +46,6 @@ public final class UriParser {
     private static final int BITS_IN_HALF_BYTE = 4;
 
     private static final char LOW_MASK = 0x0F;
-    private static final String URLENCODED_SLASH_LC = "%2f";
-
-    private static final String URLENCODED_SLASH_UC = "%2F";
 
     /**
      * Encodes and appends a string to a StringBuilder.
@@ -614,12 +449,25 @@ public final class UriParser {
      */
     public static boolean fixSeparators(final StringBuilder name) {
         boolean changed = false;
-        final int maxlen = name.length();
+        int maxlen = name.length();
         for (int i = 0; i < maxlen; i++) {
             final char ch = name.charAt(i);
             if (ch == TRANS_SEPARATOR) {
                 name.setCharAt(i, SEPARATOR_CHAR);
                 changed = true;
+            }
+            if (i < maxlen - 2 && name.charAt(i) == '%' && name.charAt(i + 1) == '2') {
+                if (name.charAt(i + 2) == 'f' || name.charAt(i + 2) == 'F') {
+                    name.setCharAt(i, SEPARATOR_CHAR);
+                    name.delete(i + 1, i + 3);
+                    maxlen -= 2;
+                    changed = true;
+                } else if (name.charAt(i + 2) == 'e' || name.charAt(i + 2) == 'E') {
+                    name.setCharAt(i, '.');
+                    name.delete(i + 1, i + 3);
+                    maxlen -= 2;
+                    changed = true;
+                }
             }
         }
         return changed;
@@ -660,21 +508,64 @@ public final class UriParser {
         // Adjust separators
         // fixSeparators(path);
 
-        // Resolve double separators, '/./' and '/../':
-        new PathNormalizer(path).run();
+        // Determine the start of the first element
+        int startFirstElem = 0;
+        if (path.charAt(0) == SEPARATOR_CHAR) {
+            if (path.length() == 1) {
+                return fileType;
+            }
+            startFirstElem = 1;
+        }
+
+        // Iterate over each element
+        int startElem = startFirstElem;
+        int maxlen = path.length();
+        while (startElem < maxlen) {
+            // Find the end of the element
+            int endElem = startElem;
+            while (endElem < maxlen && path.charAt(endElem) != SEPARATOR_CHAR) {
+                endElem++;
+            }
+
+            final int elemLen = endElem - startElem;
+            if (elemLen == 0) {
+                // An empty element - axe it
+                path.deleteCharAt(endElem);
+                maxlen = path.length();
+                continue;
+            }
+            if (elemLen == 1 && path.charAt(startElem) == '.') {
+                // A '.' element - axe it
+                path.deleteCharAt(startElem);
+                maxlen = path.length();
+                continue;
+            }
+            if (elemLen == 2 && path.charAt(startElem) == '.' && path.charAt(startElem + 1) == '.') {
+                // A '..' element - remove the previous element
+                if (startElem == startFirstElem) {
+                    // Previous element is missing
+                    throw new FileSystemException("vfs.provider/invalid-relative-path.error");
+                }
+
+                // Find start of previous element
+                int pos = startElem - 2;
+                while (pos >= 0 && path.charAt(pos) != SEPARATOR_CHAR) {
+                    pos--;
+                }
+                startElem = pos + 1;
+
+                path.delete(startElem, endElem + 1);
+                maxlen = path.length();
+                continue;
+            }
+
+            // A regular element
+            startElem = endElem + 1;
+        }
 
         // Remove trailing separator
-        if (!VFS.isUriStyle()) {
-            final int maxlen = path.length();
-            if (maxlen > 1 && path.charAt(maxlen - 1) == SEPARATOR_CHAR) {
-                path.delete(maxlen - 1, maxlen);
-            }
-            if (maxlen > 3) {
-                final String sub = path.substring(maxlen - 3);
-                if (sub.equals(URLENCODED_SLASH_UC) || sub.equals(URLENCODED_SLASH_LC)) {
-                    path.delete(maxlen - 3, maxlen);
-                }
-            }
+        if (!VFS.isUriStyle() && maxlen > 1 && path.charAt(maxlen - 1) == SEPARATOR_CHAR) {
+            path.deleteCharAt(maxlen - 1);
         }
 
         return fileType;

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/NamingTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/NamingTests.java
@@ -108,6 +108,8 @@ public class NamingTests extends AbstractProviderTestCase {
         assertSameName(path, name, "./a/foo/..", scope);
         assertSameName(path, name, "foo/../a", scope);
         assertSameName(path, name, "foo%2f..%2fa", scope);
+        assertSameName(path, name, "foo%2f/..%2fa", scope);
+        assertSameName(path, name, "foo/%2f..%2fa", scope);
 
         // Test an empty name
         assertBadName(name, "", scope);
@@ -123,6 +125,8 @@ public class NamingTests extends AbstractProviderTestCase {
         assertBadName(name, "a/..", scope);
         assertBadName(name, "%2e%2e/ab", scope);
         assertBadName(name, "..%2f../ab", scope);
+        assertBadName(name, "foo%2f..%2f..%2fa", scope);
+        assertBadName(name, "foo%2f..%2f..%2fnone-child%2fa", scope);
 
         // Test absolute names
         assertBadName(name, "/", scope);

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserBenchmark.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserBenchmark.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+public class UriParserBenchmark {
+
+    private static final String PATH_TO_NORMALIZE = "file:///this/../is/a%2flong%2Fpath/./for testing/normlisePath%2fmethod.txt";
+
+    @Benchmark
+    public void normalisePath() throws FileSystemException {
+        StringBuilder path = new StringBuilder(PATH_TO_NORMALIZE);
+        UriParser.fixSeparators(path);
+        UriParser.normalisePath(path);
+    }
+}

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -99,4 +99,21 @@ public class UriParserTest {
             fail(e);
         }
     }
+
+    @Test
+    public void testPathOfNormalizedPath() throws FileSystemException {
+        checkNormalizedPath("./Sub Folder/", "Sub Folder");
+        checkNormalizedPath("./Sub Folder/../", "");
+        checkNormalizedPath("./Sub Folder%2f..%2f", "");
+        checkNormalizedPath("File.txt", "File.txt");
+        checkNormalizedPath("./Sub Folder/./File.txt", "Sub Folder/File.txt");
+        checkNormalizedPath("./Sub Folder%2F.%2FFile.txt", "Sub Folder/File.txt");
+    }
+
+    private void checkNormalizedPath(String path, String normalized) throws FileSystemException {
+        final StringBuilder pathBuilder = new StringBuilder(path);
+        UriParser.fixSeparators(pathBuilder);
+        UriParser.normalisePath(pathBuilder);
+        assertEquals(normalized, pathBuilder.toString());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,19 @@
         <artifactId>jsr311-api</artifactId>
         <version>1.1.1</version>
       </dependency>
+      <!-- JMH Performance tests -->
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>1.37</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>1.37</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The reverts https://github.com/apache/commons-vfs/pull/396 and related
changes and implements the same in a simpler way by replacing the
encoded characters already in `fixSeparators`.

This approach has a slightly higher risk at breaking existing behaviour,
but a lower risk of remaining problems in this part of the codebase. All
testcases still succeed.

This PR is intended to replace https://github.com/apache/commons-vfs/pull/543 and https://github.com/apache/commons-vfs/pull/555. It includes the testcases
from https://github.com/apache/commons-vfs/pull/543, adapted to the behaviour before https://github.com/apache/commons-vfs/pull/396.

This reverts commit https://github.com/apache/commons-vfs/commit/cb45c9453669eb2570f582f491cb0e06b0e63466.
This reverts commit https://github.com/apache/commons-vfs/commit/5399c766287a06ce002beaed89fa8af5461e15d0.

This seems only slightly (<8%) slower than #547 , which might be acceptable as it's not obvious this is a bottleneck:

```
2290973,673 ±(99.9%) 55810,967 ops/s [Average]
2123414,134 ±(99.9%) 48374,989 ops/s [Average]
```

Should probably add some more tests exercising the problems that remain after the fixes from #543 