### PR TITLE
UriParser Fix for decoding files with open square bracket

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -328,8 +328,7 @@ public final class UriParser {
         boolean ipv6Host = false;
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
-            if (ch == '[' &&
-                    (buffer.substring(0, index).matches("\\w+://([^/]+@)?"))) {
+            if (ch == '[' && buffer.substring(0, index).matches("\\w+://([^/]+@)?")) {
                 ipv6Host = true;
             }
             if (ch == ']') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -328,7 +328,8 @@ public final class UriParser {
         boolean ipv6Host = false;
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
-            if (ch == '[' && buffer.lastIndexOf("://", index) == index - 3) {
+            if (ch == '[' &&
+                    (buffer.lastIndexOf("://", index) == index - 3 || buffer.lastIndexOf("@", index) == index - 1)) {
                 ipv6Host = true;
             }
             if (ch == ']') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -328,7 +328,7 @@ public final class UriParser {
         boolean ipv6Host = false;
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
-            if (ch == '[') {
+            if (ch == '[' && buffer.lastIndexOf("://", index) == index - 3) {
                 ipv6Host = true;
             }
             if (ch == ']') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -329,7 +329,7 @@ public final class UriParser {
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
             if (ch == '[' &&
-                    (buffer.lastIndexOf("://", index) == index - 3 || buffer.lastIndexOf("@", index) == index - 1)) {
+                    (buffer.substring(0, index).matches("\\w+://([^/]+@)?"))) {
                 ipv6Host = true;
             }
             if (ch == ']') {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -56,6 +56,7 @@ public class UriParserTest {
     @Test
     public void testBracketUriDecoding() throws FileSystemException {
         assertEquals("http://[fe80::14b5:1204:5410:64ca%en1]:8080", UriParser.decode("http://[fe80::14b5:1204:5410:64ca%en1]:8080"));
+        assertEquals("http://username@[fe80::14b5:1204:5410:64ca%en1]:8080", UriParser.decode("http://username@[fe80::14b5:1204:5410:64ca%en1]:8080"));
         assertEquals("file:/user/file [with brackets].txt", UriParser.decode("file:/user/file%20[with%20brackets].txt"));
     }
 

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -54,6 +54,12 @@ public class UriParserTest {
     }
 
     @Test
+    public void testBracketUriDecoding() throws FileSystemException {
+        assertEquals("http://[fe80::14b5:1204:5410:64ca%en1]:8080", UriParser.decode("http://[fe80::14b5:1204:5410:64ca%en1]:8080"));
+        assertEquals("file:/user/file [with brackets].txt", UriParser.decode("file:/user/file%20[with%20brackets].txt"));
+    }
+
+    @Test
     public void testNormalScheme() {
         assertEquals("ftp", UriParser.extractScheme(schemes, "ftp://user:pass@host/some/path/some:file"));
     }


### PR DESCRIPTION
Detection of IPv6 ip addresses should ignore decoding of %nn text. It is done at the moment in the buffer length (from decode(String) instead of where the host name should be. This result in incorrect decoding of files like 'file%20[hello%20world].txt as all text after [ (and before ] if present) is not decoded.