### PR TITLE
Fixed commons-vfs sandbox module not compiling due to missing imports and library

### DIFF
--- a/commons-vfs2-sandbox/pom.xml
+++ b/commons-vfs2-sandbox/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
       <optional>true</optional>
@@ -77,11 +81,6 @@
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeAttributesMap.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeAttributesMap.java
@@ -33,7 +33,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import jakarta.mail.Address;
+import jakarta.mail.Header;
+import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Part;
 import jakarta.mail.internet.MimeMessage;
 
 /**
@@ -136,19 +139,19 @@ public class MimeAttributesMap implements Map<String, Object> {
         if (part instanceof MimeMessage) {
             final MimeMessage message = (MimeMessage) part;
             try {
-                final Address[] address = message.getRecipients(RecipientType.BCC);
+                final Address[] address = message.getRecipients(Message.RecipientType.BCC);
                 ret.put(OBJECT_PREFIX + "Recipients.BCC", address);
             } catch (final MessagingException e) {
                 log.debug(e.getLocalizedMessage(), e);
             }
             try {
-                final Address[] address = message.getRecipients(RecipientType.CC);
+                final Address[] address = message.getRecipients(Message.RecipientType.CC);
                 ret.put(OBJECT_PREFIX + "Recipients.CC", address);
             } catch (final MessagingException e) {
                 log.debug(e.getLocalizedMessage(), e);
             }
             try {
-                final Address[] address = message.getRecipients(RecipientType.TO);
+                final Address[] address = message.getRecipients(Message.RecipientType.TO);
                 ret.put(OBJECT_PREFIX + "Recipients.TO", address);
             } catch (final MessagingException e) {
                 log.debug(e.getLocalizedMessage(), e);

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileContentInfoFactory.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileContentInfoFactory.java
@@ -23,6 +23,8 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.impl.DefaultFileContentInfo;
 
 import jakarta.mail.MessagingException;
+import jakarta.mail.Part;
+import jakarta.mail.internet.ContentType;
 
 /**
  * Gets access to the content info stuff for mime objects.
@@ -31,7 +33,7 @@ public class MimeFileContentInfoFactory implements FileContentInfoFactory {
     @Override
     public FileContentInfo create(final FileContent fileContent) throws FileSystemException {
         final MimeFileObject mimeFile = (MimeFileObject) fileContent.getFile();
-        final Part part = mimeFile.getPart();
+        final Part part = (Part) mimeFile.getPart();
 
         String contentTypeString = null;
         String charset = null;

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileObject.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileObject.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.vfs2.provider.mime;
 
+import jakarta.mail.Header;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.apache.commons.vfs2.util.FileObjectUtils;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
+import jakarta.mail.Part;
 import jakarta.mail.internet.MimeMultipart;
 
 /**
@@ -64,7 +66,7 @@ public class MimeFileObject extends AbstractFileObject<MimeFileSystem> implement
                 return;
             }
 
-            setPart(((MimeFileSystem) getFileSystem()).createCommunicationLink());
+            setPart((Part) ((MimeFileSystem) getFileSystem()).createCommunicationLink());
         }
     }
 

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileSystem.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/mime/MimeFileSystem.java
@@ -33,6 +33,7 @@ import org.apache.commons.vfs2.provider.AbstractFileSystem;
 import org.apache.commons.vfs2.util.SharedRandomContentInputStream;
 
 import jakarta.mail.MessagingException;
+import jakarta.mail.Part;
 import jakarta.mail.internet.MimeMessage;
 
 /**

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/util/FileObjectDataSource.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/util/FileObjectDataSource.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import javax.activation.DataSource;
+import jakarta.activation.DataSource;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;


### PR DESCRIPTION
Fix for the sub-module `commons-vfs2-sandbox` not compiling