### PR TITLE
VFS-859: Fix undeclared direct dependencies

### DIFF
--- a/commons-vfs2-ant/pom.xml
+++ b/commons-vfs2-ant/pom.xml
@@ -34,35 +34,22 @@
   <description>Apache Commons VFS Ant Tasks.</description>
 
   <dependencies>
+
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>
-    <dependency>
-       <groupId>org.apache.commons</groupId>
-       <artifactId>commons-vfs2</artifactId>
-       <type>test-jar</type>
-       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+
   </dependencies>
 
   <properties>

--- a/commons-vfs2-examples/pom.xml
+++ b/commons-vfs2-examples/pom.xml
@@ -34,30 +34,35 @@
   </parent>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>
 
+    <!-- Optional dependencies -->
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <optional>true</optional>
-    </dependency>
+
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <optional>true</optional>
     </dependency>
+
   </dependencies>
 
   <properties>
     <commons.parent.dir>${basedir}/..</commons.parent.dir>
+    <commons.module.name>org.apache.commons.vfs2.examples</commons.module.name>
     <japicmp.skip>true</japicmp.skip>
     <commons.osgi.import>
         *
@@ -136,6 +141,26 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>verify-undeclared-deps</id>
+                <configuration>
+                  <!-- Runtime-only dependencies go here -->
+                  <ignoredUnusedDeclaredDependencies combine.children="append">
+                    <dependency>commons-httpclient:commons-httpclient</dependency>
+                  </ignoredUnusedDeclaredDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -153,6 +178,26 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>verify-undeclared-deps</id>
+                <configuration>
+                  <!-- Runtime-only dependencies go here -->
+                  <ignoredUnusedDeclaredDependencies combine.children="append">
+                    <dependency>org.apache.httpcomponents:httpclient</dependency>
+                  </ignoredUnusedDeclaredDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -170,6 +215,27 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
+
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>verify-undeclared-deps</id>
+                <configuration>
+                  <!-- Runtime-only dependencies go here -->
+                  <ignoredUnusedDeclaredDependencies combine.children="append">
+                    <dependency>org.apache.httpcomponents.client5:httpclient5</dependency>
+                  </ignoredUnusedDeclaredDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/commons-vfs2-hdfs/pom.xml
+++ b/commons-vfs2-hdfs/pom.xml
@@ -34,49 +34,62 @@
   <description>Apache Commons VFS is a Virtual File System library - Apache Hadoop HDFS provider.</description>
 
   <dependencies>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs-client</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
+
+    <!--
+      ~ Tests: compile dependencies
+      -->
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-vfs2</artifactId>
        <type>test-jar</type>
        <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Test HDFS with Apache Hadoop -->
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
@@ -84,26 +97,63 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-         <!-- VFS-606 - tools.jar not available in Java 9
-              This exclusion can be removed after upgrading Hadoop
-              to 2.7.1 or later  
-          -->
-          <groupId>jdk.tools</groupId>
-          <artifactId>jdk.tools</artifactId>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Remove unused dependencies with vulnerabilities -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+     ~ Tests: runtime dependencies
+     -->
+    <dependency>
+      <!-- Runtime dependency of `hadoop-hdfs:test-jar` -->
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <!-- Remove unused dependencies with vulnerabilities -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <!-- Runtime dependency of `hadoop-hdfs:test-jar` -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <properties>
@@ -218,6 +268,23 @@
             </dependency>
 		  </dependencies>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-undeclared-deps</id>
+            <configuration>
+              <!-- Runtime-only test dependencies go here -->
+              <ignoredUnusedDeclaredDependencies combine.children="append">
+                <dependency>org.apache.hadoop:hadoop-common:test-jar</dependency>
+                <dependency>org.mockito:mockito-core</dependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/commons-vfs2-hdfs/src/test/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileProviderTest.java
+++ b/commons-vfs2-hdfs/src/test/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileProviderTest.java
@@ -39,10 +39,8 @@ import org.apache.commons.vfs2.util.RandomAccessMode;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -109,7 +107,6 @@ public class HdfsFileProviderTest {
     @BeforeAll
     public static void setUp() throws Exception {
         System.setProperty("test.basedir", "../commons-vfs2/target/test-classes/test-data");
-        Logger.getRootLogger().setLevel(Level.ERROR);
 
         // Put the MiniDFSCluster directory in the target directory
         final File data = new File("target/test/hdfstestdata").getAbsoluteFile();
@@ -121,7 +118,7 @@ public class HdfsFileProviderTest {
         conf = new Configuration();
         conf.set(FileSystem.FS_DEFAULT_NAME_KEY, HDFS_URI);
         conf.set("hadoop.security.token.service.use_ip", "true");
-        conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024); // 1M block size
+        conf.setLong(HdfsClientConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024); // 1M block size
 
         setUmask(conf);
 

--- a/commons-vfs2-hdfs/src/test/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileProviderTestCase.java
+++ b/commons-vfs2-hdfs/src/test/java/org/apache/commons/vfs2/provider/hdfs/HdfsFileProviderTestCase.java
@@ -36,10 +36,8 @@ import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.junit.Assume;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -93,7 +91,6 @@ public class HdfsFileProviderTestCase extends AbstractProviderTestConfig {
         protected void setUp() throws Exception {
             Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
             System.setProperty("test.basedir", "../commons-vfs2/target/test-classes/test-data");
-            Logger.getRootLogger().setLevel(Level.OFF);
 
             // Put the MiniDFSCluster directory in the target directory
             final File data = new File("target/test/hdfstestcasedata").getAbsoluteFile();
@@ -105,7 +102,7 @@ public class HdfsFileProviderTestCase extends AbstractProviderTestConfig {
             conf = new Configuration();
             conf.set(FileSystem.FS_DEFAULT_NAME_KEY, HDFS_URI);
             conf.set("hadoop.security.token.service.use_ip", "true");
-            conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024); // 1M block size
+            conf.setLong(HdfsClientConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024); // 1M block size
 
             HdfsFileProviderTest.setUmask(conf);
 

--- a/commons-vfs2-jackrabbit1/pom.xml
+++ b/commons-vfs2-jackrabbit1/pom.xml
@@ -36,28 +36,13 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
     </dependency>
 
     <dependency>
@@ -66,6 +51,9 @@
       <version>${jackrabbit1.version}</version>
     </dependency>
 
+    <!--
+      ~ Tests: compile dependencies
+      -->
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-vfs2</artifactId>
@@ -74,37 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.5.11</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -205,6 +164,26 @@
             <exclude>**/*Tests.java</exclude>
           </excludes>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-undeclared-deps</id>
+            <configuration>
+              <ignoredNonTestScopedDependencies>
+                <!-- Used only in tests, but also transitive dependency of a `compile` dependency -->
+                <dependency>commons-io:commons-io</dependency>
+              </ignoredNonTestScopedDependencies>
+              <ignoredUsedUndeclaredDependencies>
+                <!-- Used only in tests, but also transitive dependency of a `compile` dependency -->
+                <dependency>commons-io:commons-io</dependency>
+              </ignoredUsedUndeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/commons-vfs2-jackrabbit2/pom.xml
+++ b/commons-vfs2-jackrabbit2/pom.xml
@@ -34,23 +34,24 @@
   <description>Apache Commons VFS is a Virtual File System library - Jackrabbit2-based WebDAV provider.</description>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
@@ -62,46 +63,84 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!--
+      ~ Tests: compile dependencies
+      -->
     <dependency>
-       <groupId>org.apache.commons</groupId>
-       <artifactId>commons-vfs2</artifactId>
-       <type>test-jar</type>
-       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <groupId>commons-chain</groupId>
+      <artifactId>commons-chain</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-jcr-commons</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Test WebDAV with Apache Jackrabbit2 Standalone Components -->
+
     <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-jcr-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!-- Test WebDAV with Apache Jackrabbit2 Standalone Components -->
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-standalone-components</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- Almost certainly unused -->
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <properties>
@@ -191,6 +230,27 @@
             <exclude>**/*Tests.java</exclude>
           </excludes>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-undeclared-deps</id>
+            <configuration>
+              <ignoredNonTestScopedDependencies>
+                <!-- Used only in tests, but also transitive dependency of a `compile` dependency -->
+                <dependency>commons-io:commons-io</dependency>
+              </ignoredNonTestScopedDependencies>
+              <ignoredUsedUndeclaredDependencies>
+                <!-- Used only in tests, but also transitive dependency of a `compile` dependency -->
+                <dependency>commons-io:commons-io</dependency>
+                <dependency>org.apache.httpcomponents:httpcore</dependency>
+              </ignoredUsedUndeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -31,123 +31,132 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-      <optional>true</optional>
-    </dependency>
+
+    <!-- Optional compile dependencies -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <optional>true</optional>
     </dependency>
-    <!-- Tests -->
+
+    <!-- Tests: compile dependencies -->
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
+      <groupId>org.apache.ftpserver</groupId>
+      <artifactId>ftplet-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <!-- Test FTP with Apache FTP Server (MINA) -->
+
     <dependency>
       <groupId>org.apache.ftpserver</groupId>
       <artifactId>ftpserver-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Test SFTP with Apache SHHd Server (MINA) -->
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <!-- Test HTTP with Apache HttpComponent Core -->
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-nio</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- JMH Performance tests -->
-    <dependency>
+      <!-- JMH Performance tests -->
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.mina</groupId>
+      <artifactId>mina-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!-- Test SFTP with Apache SHHd Server (MINA) -->
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+      ~ Tests: runtime dependencies
+      -->
+    <dependency>
+      <!-- Required by SFTP tests -->
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk16</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <properties>
@@ -160,10 +169,6 @@
   </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-      </plugins>
-    </pluginManagement>
     <resources>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
@@ -236,6 +241,11 @@
             <test.basedir>target/test-classes/test-data</test.basedir>
             <test.basedir.res>test-data</test.basedir.res>
             <derby.stream.error.file>target/derby.log</derby.stream.error.file>
+            <!--
+              ~ Directory with SSH private keys.
+              ~ Since Jsch chokes on new types of private keys, we use any folder that DOES NOT contain SSH keys.
+              -->
+            <vfs.sftp.sshdir>target/classes</vfs.sftp.sshdir>
           </systemPropertyVariables>
           <excludes>
             <!-- Main class -->
@@ -247,6 +257,22 @@
             <exclude>**/*Tests.java</exclude>
           </excludes>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-undeclared-deps</id>
+            <configuration>
+              <!-- Runtime-only test dependencies go here -->
+              <ignoredUnusedDeclaredDependencies combine.children="append">
+                <dependency>org.bouncycastle:bcprov-jdk16</dependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <clirr.skip>true</clirr.skip>
     <japicmp.skip>false</japicmp.skip>
     <jacoco.skip>false</jacoco.skip>
+    <ftpserver.version>1.2.1</ftpserver.version>
     <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>2025-02-14T13:36:40Z</project.build.outputTimestamp>
   </properties>
@@ -275,6 +276,43 @@
           <excludeFilterFile>${commons.parent.dir}/findbugs-exclude-filter.xml</excludeFilterFile>
         </configuration>
       </plugin>
+
+      <!--
+        ~ Verify the presence of undeclared direct dependencies to prevent problems like:
+        ~ https://issues.apache.org/jira/browse/VFS-859
+        -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-obsolete-exclusions</id>
+            <goals>
+              <goal>analyze-exclusions</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <exclusionFail>true</exclusionFail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-undeclared-deps</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <!-- Runtime-only test dependencies go here -->
+              <ignoredUnusedDeclaredDependencies>
+                <dependency>org.apache.logging.log4j:log4j-core</dependency>
+                <dependency>org.apache.logging.log4j:log4j-slf4j2-impl</dependency>
+                <!-- Some test suites are not JUnit 5 yet -->
+                <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -381,6 +419,16 @@
 
       <!-- 3rd party dependencies -->
       <dependency>
+        <groupId>commons-chain</groupId>
+        <artifactId>commons-chain</artifactId>
+        <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>1.9.0</version>
+      </dependency>
+      <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.3.5</version>
@@ -404,6 +452,11 @@
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
         <version>${httpclient3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -453,32 +506,30 @@
       <!-- HDFS -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-hdfs-client</artifactId>
-        <version>${hadoop.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs</artifactId>
         <version>${hadoop.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdfs-client</artifactId>
+        <version>${hadoop.version}</version>
       </dependency>
       <!-- Testing -->
+      <dependency>
+        <groupId>javax.jcr</groupId>
+        <artifactId>jcr</artifactId>
+        <version>2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
@@ -494,8 +545,13 @@
       <!-- Test FTP with Apache FTP Server (MINA) -->
       <dependency>
         <groupId>org.apache.ftpserver</groupId>
+        <artifactId>ftplet-api</artifactId>
+        <version>${ftpserver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ftpserver</groupId>
         <artifactId>ftpserver-core</artifactId>
-        <version>1.2.1</version>
+        <version>${ftpserver.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -551,10 +607,29 @@
       <!-- Test WebDAV with Apache Jackrabbit2 Standalone Components -->
       <dependency>
         <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-core</artifactId>
+        <version>${jackrabbit2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-commons</artifactId>
+        <version>${jackrabbit2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-servlet</artifactId>
+        <version>${jackrabbit2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
         <artifactId>jackrabbit-standalone-components</artifactId>
         <version>${jackrabbit2.version}</version>
         <scope>test</scope>
       </dependency>
+
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
@@ -568,13 +643,6 @@
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <type>test-jar</type>
-        <exclusions>
-          <exclusion>
-            <!-- jackrabbit-standalone provides one, too -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -600,8 +668,46 @@
         <version>1.37</version>
         <scope>test</scope>
       </dependency>
+
+      <!--
+        ~ BOMs at the end, so they don't override other dependencies
+        -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>9.4.56.v20240826</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <!-- Common dependencies in tests -->
+  <dependencies>
+    <!--
+      ~ Tests: compile dependencies
+      -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+      ~ Tests: runtime dependencies
+      -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <distributionManagement>
     <site>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action dev="ggregory" type="fix" due-to="Gary Gregory">Rework FTPClientWrapper.disconnect() to remove any chance of a new connection being created on demand.</action>
       <action dev="ggregory" type="fix" due-to="Gary Gregory">The write buffer size in DefaultFileContent is now 8K instead of 4K.</action>
       <action dev="ggregory" type="fix" due-to="Anthony Goubard">Improve performance of encoding URIs #660.</action>
+      <action dev="pkarwasz" type="fix">Fixes optional dependencies in JPMS descriptors.</action>
       <!-- ADD -->
       <action dev="ggregory" type="add" due-to="Gary Gregory">Add org.apache.commons.vfs2.provider.ftp.FTPClientWrapper.sendOptions(String, String).</action>
       <action dev="ggregory" type="add" due-to="Gary Gregory">Add FtpFileSystemConfigBuilder.getControlEncodingCharset(FileSystemOptions) and deprecate getControlEncoding(FileSystemOptions).</action>


### PR DESCRIPTION
Undeclared direct dependencies that are also transitive dependencies of an **optional** direct dependency, end up being declared by Moditect using `requires <module>` instead of `requires static <module>`.

This causes JPMS runtime errors, unless the optional dependency is present on the module path.

To solve this and rationalize the dependency tree, this change:

- Adds two verification rules that check for undeclared dependencies and useless exclusions.
- Adds undeclared dependencies to the POM files.
- Remove unused declared dependencies.

