### PR TITLE
Fix Javadoc for ResourceFileSystemConfigBuilder

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/res/ResourceFileSystemConfigBuilder.java
@@ -22,7 +22,7 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.url.UrlFileSystem;
 
 /**
- * Configuration options builder utility for resources access.
+ * Configuration options builder for resources access.
  */
 public final class ResourceFileSystemConfigBuilder extends FileSystemConfigBuilder {
 


### PR DESCRIPTION
It seems there is copy-paste error in `ResourceFileSystemConfigBuilder` javadoc. For some reason it describes that it helps with `FTP`, but it's not.