### PR TITLE
Vfs 860 bom

### DIFF
--- a/commons-vfs2-bom/pom.xml
+++ b/commons-vfs2-bom/pom.xml
@@ -63,5 +63,377 @@
 	<checkstyle.skip>true</checkstyle.skip>
     <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>2025-02-14T13:36:40Z</project.build.outputTimestamp>
+    <commons.encoding>UTF-8</commons.encoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- bare ID without major version or commons- prefix -->
+    <commons.componentid>vfs</commons.componentid>
+    <commons.packageId>vfs2</commons.packageId>
+    <commons.module.name>org.apache.commons.vfs2</commons.module.name>
+    <commons.jira.id>VFS</commons.jira.id>
+    <commons.jira.pid>12310495</commons.jira.pid>
+    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-vfs</commons.scmPubUrl>
+    <commons.siteOutputDirectory>${basedir}/target/site</commons.siteOutputDirectory>
+    <commons.releaseNotesLocation>${commons.parent.dir}/RELEASE-NOTES.txt</commons.releaseNotesLocation>
+    <commons.distSvnStagingUrl>scm:svn:https://dist.apache.org/repos/dist/dev/commons/${commons.componentid}</commons.distSvnStagingUrl>
+    <commons.release.version>2.11.0</commons.release.version>
+    <commons.release.next>2.11.1</commons.release.next>
+    <!-- Commons Release Plugin -->
+    <!-- Previous version of the component (used for reporting binary compatibility check)-->
+    <commons.bc.version>2.10.0</commons.bc.version>
+    <!--
+      Define the following in ~/.m2/settings.xml in an active profile:
+      (or provide them on the command line)
+      commons.releaseManagerName
+      commons.releaseManagerKey
+    -->
+    <commons.rc.version>RC1</commons.rc.version>
+    <commons.release.name>commons-vfs-${commons.release.version}</commons.release.name>
+    <commons.release.desc>(requires Java 8 or above)</commons.release.desc>
+    <commons.release.isDistModule>false</commons.release.isDistModule>
+    <!-- make sure bundle plugin has dependency informations for 'optional' -->
+    <commons.osgi.excludeDependencies />
+    <commons.osgi.import>
+      *
+    </commons.osgi.import>
+    <!-- Avoid warnings about being unable to find jars during site building -->
+    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <hadoop.version>3.4.1</hadoop.version>
+    <httpcore5.version>5.3.4</httpcore5.version>
+    <httpclient5.version>5.5</httpclient5.version>
+    <jackrabbit1.version>1.6.5</jackrabbit1.version>
+    <!-- Don't use jackrabbit2 2.21.x, it's labeled "unstable". -->
+    <!-- 2.22.0 requires Java 11. -->
+    <jackrabbit2.version>2.20.16</jackrabbit2.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <log4j2.version>2.25.0</log4j2.version>
+    <collections4.version>4.5.0</collections4.version>
+    <jsch.version>0.1.55</jsch.version>
+    <httpclient3.version>3.1</httpclient3.version>
+    <ant.version>1.10.15</ant.version>
+    <clirr.skip>true</clirr.skip>
+    <japicmp.skip>false</japicmp.skip>
+    <jacoco.skip>false</jacoco.skip>
+    <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+    <project.build.outputTimestamp>2025-02-14T13:36:40Z</project.build.outputTimestamp>
   </properties>
+  <build>
+    <!-- japicmp:cmp needs package to work from a jar -->
+    <defaultGoal>clean verify apache-rat:check japicmp:cmp javadoc:javadoc spotbugs:check pmd:check checkstyle:check</defaultGoal>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <!-- Keep build/reporting in sync -->
+          <configuration>
+            <!--<propertiesLocation>${commons.parent.dir}/checkstyle.properties</propertiesLocation> -->
+            <configLocation>${commons.parent.dir}/checkstyle.xml</configLocation>
+            <suppressionsLocation>${commons.parent.dir}/checkstyle-suppressions.xml</suppressionsLocation>
+            <enableRulesSummary>false</enableRulesSummary>
+            <propertyExpansion>basedir=${basedir}</propertyExpansion>
+            <!-- <includeTestSourceDirectory>true</includeTestSourceDirectory> -->
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <!-- Should agree with config in reporting section -->
+          <configuration>
+            <excludes combine.children="append">
+              <!--  trivial test data text files -->
+              <exclude>src/test/resources/test-data/**/*.bin</exclude>
+              <exclude>src/test/resources/test-data/**/*.txt</exclude>
+              <exclude>src/test/resources/test-data/**/*.tgz</exclude>
+              <exclude>src/test/resources/test-data/**/*.tbz2</exclude>
+              <exclude>src/test/resources/test-data/test.mf</exclude>
+              <!--  implicite exclude does not work if sandbox profile is not activated -->
+              <exclude>commons-vfs2-sandbox/**</exclude>
+              <exclude>dist/target/**</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <configuration>
+            <parameter>
+              <overrideCompatibilityChangeParameters>
+                <overrideCompatibilityChangeParameter>
+                  <compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+                  <binaryCompatible>true</binaryCompatible>
+                  <sourceCompatible>true</sourceCompatible>
+                  <semanticVersionLevel>PATCH</semanticVersionLevel>
+                </overrideCompatibilityChangeParameter>
+                <overrideCompatibilityChangeParameter>
+                  <!-- BC is maintained, but no SC. -->
+                  <compatibilityChange>METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION</compatibilityChange>
+                  <binaryCompatible>true</binaryCompatible>
+                  <sourceCompatible>true</sourceCompatible>
+                  <semanticVersionLevel>PATCH</semanticVersionLevel>
+                </overrideCompatibilityChangeParameter>
+              </overrideCompatibilityChangeParameters>
+              <excludes>
+                <!-- Remove this section after 2.10.0 -->
+                <!-- Package moved to new module commons-vfs-hdfs -->
+                <exclude>org.apache.commons.vfs2.provider.hdfs</exclude>
+                <!-- Package moved to new module commons-vfs-ant -->
+                <exclude>org.apache.commons.vfs2.tasks</exclude>
+              </excludes>
+            </parameter>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <configuration>
+            <targetJdk>${maven.compiler.target}</targetJdk>
+            <rulesets>
+              <ruleset>${commons.parent.dir}/src/conf/pmd-ruleset.xml</ruleset>
+            </rulesets>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <resources>
+      <resource>
+        <directory>${basedir}/osgi</directory>
+        <targetPath>osgi</targetPath>
+        <includes>
+          <include>MANIFEST.MF</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>vfs-jar-manifest</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.directory}/osgi" />
+                <touch file="${project.build.directory}/osgi/MANIFEST.MF" />
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>javadoc.resources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy todir="${project.build.directory}/apidocs/META-INF">
+                  <fileset dir="${commons.parent.dir}">
+                    <include name="LICENSE.txt" />
+                    <include name="NOTICE.txt" />
+                  </fileset>
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xmx64m</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <threshold>Normal</threshold>
+          <effort>Default</effort>
+          <excludeFilterFile>${commons.parent.dir}/findbugs-exclude-filter.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${commons.javadoc.version}</version>
+        <configuration>
+          <tags>
+            <tag>
+              <name>todo</name>
+              <!-- todo tag for all places -->
+              <placement>a</placement>
+              <head>To Do:</head>
+            </tag>
+          </tags>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>jxr-no-fork</report>
+              <report>test-jxr-no-fork</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <threshold>Normal</threshold>
+          <effort>Default</effort>
+          <excludeFilterFile>${commons.parent.dir}/findbugs-exclude-filter.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <targetJdk>${maven.compiler.target}</targetJdk>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>pmd</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+  <developers>
+    <developer>
+      <name>Adam Murdoch</name>
+      <id>adammurdoch</id>
+      <email>adammurdoch -at- apache.org</email>
+      <organization />
+    </developer>
+    <developer>
+      <name>James Strachan</name>
+      <id>jstrachan</id>
+      <email>jstrachan -at- apache.org</email>
+      <organization>SpiritSoft, Inc.</organization>
+    </developer>
+    <developer>
+      <name>Mario Ivankovits</name>
+      <id>imario</id>
+      <email>imario -at- apache.org</email>
+      <organization>OPS EDV Gmbh</organization>
+    </developer>
+    <developer>
+      <name>Rahul Akolkar</name>
+      <id>rahul</id>
+      <email>rahul -at- apache.org</email>
+      <organization>The Apache Software Foundation</organization>
+    </developer>
+    <developer>
+      <name>James Carman</name>
+      <id>jcarman</id>
+      <email>jcarman -at- apache.org</email>
+      <organization>The Apache Software Foundation</organization>
+    </developer>
+    <developer>
+      <name>Ralph Goers</name>
+      <id>rgoers</id>
+      <email>rgoers -at- apache.org</email>
+      <organization>Intuit</organization>
+    </developer>
+    <developer>
+      <name>Joerg Schaible</name>
+      <id>joehni</id>
+      <email>joehni -at- apache.org</email>
+    </developer>
+    <developer>
+      <id>ggregory</id>
+      <name>Gary Gregory</name>
+      <email>ggregory at apache.org</email>
+      <url>https://www.garygregory.com</url>
+      <organization>The Apache Software Foundation</organization>
+      <organizationUrl>https://www.apache.org/</organizationUrl>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>America/New_York</timezone>
+      <properties>
+        <picUrl>https://people.apache.org/~ggregory/img/garydgregory80.png</picUrl>
+      </properties>
+    </developer>
+    <developer>
+      <name>Bernd Eckenfels</name>
+      <id>ecki</id>
+      <email>ecki -at- apache.org</email>
+      <url>https://bernd.eckenfels.net</url>
+      <timezone>+1</timezone>
+    </developer>
+  </developers>
+  <contributors>
+    <contributor>
+      <name>Rami Ojares</name>
+      <email>rami.ojares -at- elisa.fi</email>
+    </contributor>
+    <contributor>
+      <name>Anthony Goubard</name>
+      <email>anthony.goubard -at- japplis.com</email>
+    </contributor>
+    <contributor>
+      <name>Christopher Ottley</name>
+      <email>xknight -at- users.sourceforge.net</email>
+    </contributor>
+    <contributor>
+      <name>Dave Marion</name>
+      <email>dlmarion -at- apache.org</email>
+    </contributor>
+    <contributor>
+      <name>Scott Bjerstedt</name>
+      <email>jcottbjer -at- gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>Jose Juan Montiel</name>
+      <email>josejuan.montiel -at- gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>Otto Fowler</name>
+      <email>otto -at- apache.org</email>
+    </contributor>
+  </contributors>
 </project>

--- a/commons-vfs2-bom/pom.xml
+++ b/commons-vfs2-bom/pom.xml
@@ -18,13 +18,9 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.commons</groupId>
-    <artifactId>commons-vfs2-project</artifactId>
-    <version>2.11.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
+  <groupId>org.apache.commons</groupId>
   <artifactId>commons-vfs2-bom</artifactId>
+  <version>2.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Commons VFS Bill of Materials</name>
   <description>This Bill of Materials POM can be used to ease dependency management when referencing multiple artifacts using Maven.</description>


### PR DESCRIPTION
commons-vfs2-bom has commons-vfs2-project as a parent. When you import it into a different project, you expect to have this project's dependencies managed only, but instead, you get numerous other dependencies managed from commons-vfs2-project and its parents.
This pull request detaches the BOM from its parent, which is the only way to get rid of unwanted dependency management.
Unfortunately, as the BOM is part of the reactor, other parts of the parent POM are required for the build to succeed, and we must manually copy them. The only solution for this would be to remove the BOM from the reactor itself, as building a BOM is trivial and probably allows for a much simpler POM file to be written for it. However, the BOM would then need to be built separately.
