### PR TITLE
Fix acquireEndpoint timeout

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/http5/Http5FileObject.java
@@ -34,6 +34,7 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpHead;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -122,6 +123,12 @@ public class Http5FileObject<FS extends Http5FileSystem> extends AbstractFileObj
         final ClassicHttpResponse httpResponse = executeHttpUriRequest(getRequest);
         final int status = httpResponse.getCode();
 
+        if (status != HttpStatus.SC_OK) {
+            if (httpResponse instanceof CloseableHttpResponse) {
+                ((CloseableHttpResponse) httpResponse).close();
+            }
+        }
+
         if (status == HttpStatus.SC_NOT_FOUND) {
             throw new FileNotFoundException(getName());
         }
@@ -153,6 +160,10 @@ public class Http5FileObject<FS extends Http5FileSystem> extends AbstractFileObj
     protected FileType doGetType() throws Exception {
         lastHeadResponse = executeHttpUriRequest(new HttpHead(getInternalURI()));
         final int status = lastHeadResponse.getCode();
+
+        if (lastHeadResponse instanceof CloseableHttpResponse) {
+            ((CloseableHttpResponse) lastHeadResponse).close();
+        }
 
         if (status == HttpStatus.SC_OK
                 || status == HttpStatus.SC_METHOD_NOT_ALLOWED /* method is not allowed, but resource exist */) {


### PR DESCRIPTION
Step1: Read HTTP File which not exist.(NOT FOUND)
Step2: Read HTTP File exist

STEP1 READ FILE NOT EXIST:
```
  Could not read from "http://10.x.x.x:5000/fail.xlsx" because it is not a file.
       at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:401)
       at org.apache.hop.pipeline.transforms.excelinput.staxpoi.StaxPoiWorkbook.<init>(StaxPoiWorkbook.java:74)
       ... 5 more
  Caused by: org.apache.commons.vfs2.FileNotFoundException: Could not read from "http://10.15.40.230:5000/AI-fail.xlsx" because it is not a file.
       at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1197)
       at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1182)
       at org.apache.commons.vfs2.provider.DefaultFileContent.buildInputStream(DefaultFileContent.java:258)
       at org.apache.commons.vfs2.provider.DefaultFileContent.getInputStream(DefaultFileContent.java:526)
       at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:381)
       at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:399)
       ... 6 more
  Caused by: org.apache.commons.vfs2.FileNotFoundException: Could not read from "http://10.15.40.230:5000/AI-fail.xlsx" because it is not a file.
       at org.apache.commons.vfs2.provider.http5.Http5FileObject.doGetInputStream(Http5FileObject.java:133)
       at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1195)
       ... 11 more
```

 STEP2 READ FILE EXIST:
```
 Could not read file "http://10.x.x.x:5000/succ.xlsx".

   at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:401)
   at org.apache.hop.pipeline.transforms.excelinput.staxpoi.StaxPoiWorkbook.<init>(StaxPoiWorkbook.java:74)
   ... 5 more
 Caused by: org.apache.commons.vfs2.FileSystemException: Could not read file "http://10.15.40.230:5000/AI.xlsx".
   at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1216)
   at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1182)
   at org.apache.commons.vfs2.provider.DefaultFileContent.buildInputStream(DefaultFileContent.java:258)
   at org.apache.commons.vfs2.provider.DefaultFileContent.getInputStream(DefaultFileContent.java:526)
   at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:381)
   at org.apache.hop.core.vfs.HopVfs.getInputStream(HopVfs.java:399)
   ... 6 more
 Caused by: org.apache.hc.core5.http.ConnectionRequestTimeoutException: Timeout deadline: 180000 MILLISECONDS, actual: 180000 MILLISECONDS
   at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.acquireEndpoint(InternalExecRuntime.java:120)
   at org.apache.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:125)
   at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
   at org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:192)
   at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
   at org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec.execute(HttpRequestRetryExec.java:113)
   at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
   at org.apache.hc.client5.http.impl.classic.ContentCompressionExec.execute(ContentCompressionExec.java:152)
   at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
   at org.apache.hc.client5.http.impl.classic.RedirectExec.execute(RedirectExec.java:116)
   at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
   at org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:170)
   at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:106)
   at org.apache.commons.vfs2.provider.http5.Http5FileObject.executeHttpUriRequest(Http5FileObject.java:194)
   at org.apache.commons.vfs2.provider.http5.Http5FileObject.doGetInputStream(Http5FileObject.java:123)
   at org.apache.commons.vfs2.provider.AbstractFileObject.getInputStream(AbstractFileObject.java:1195)
   ... 11 more
```