### PR TITLE
Restrict reflective class loading in webdav ExceptionConverter

### DIFF
--- a/commons-vfs2-jackrabbit1/src/main/java/org/apache/commons/vfs2/provider/webdav/ExceptionConverter.java
+++ b/commons-vfs2-jackrabbit1/src/main/java/org/apache/commons/vfs2/provider/webdav/ExceptionConverter.java
@@ -62,14 +62,17 @@ public final class ExceptionConverter {
                         msg = DomUtil.getChildText(exc, "message", null);
                     }
                     if (DomUtil.hasChildElement(exc, "class", null)) {
-                        final Class<?> cl = Class.forName(DomUtil.getChildText(exc, "class", null));
-                        final Constructor<?> excConstr = cl.getConstructor(String.class);
-                        final Object o = excConstr.newInstance(msg);
-                        if (o instanceof FileSystemException) {
-                            return (FileSystemException) o;
-                        }
-                        if (o instanceof Exception) {
-                            return new FileSystemException(msg, (Exception) o);
+                        final Class<?> cl = Class.forName(DomUtil.getChildText(exc, "class", null), false,
+                                ExceptionConverter.class.getClassLoader());
+                        if (Exception.class.isAssignableFrom(cl)) {
+                            final Constructor<?> excConstr = cl.getConstructor(String.class);
+                            final Object o = excConstr.newInstance(msg);
+                            if (o instanceof FileSystemException) {
+                                return (FileSystemException) o;
+                            }
+                            if (o instanceof Exception) {
+                                return new FileSystemException(msg, (Exception) o);
+                            }
                         }
                     }
                 }

--- a/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/ExceptionConverterTest.java
+++ b/commons-vfs2-jackrabbit1/src/test/java/org/apache/commons/vfs2/provider/webdav/ExceptionConverterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.webdav;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.jackrabbit.webdav.DavException;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+/**
+ * Tests {@link ExceptionConverter}.
+ */
+public class ExceptionConverterTest {
+
+    /** Marker class named by the crafted server response; must never be instantiated. */
+    public static final class Marker {
+        static volatile boolean instantiated;
+
+        public Marker(final String message) {
+            instantiated = true;
+        }
+    }
+
+    /**
+     * Builds a {@link DavException} whose error condition carries an {@code <exception><class>} element, as parsed from a
+     * malicious WebDAV server error body.
+     */
+    private DavException davExceptionNaming(final String className) throws Exception {
+        final String xml = "<exception><class>" + className + "</class><message>boom</message></exception>";
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        final Document doc = dbf.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+        final Element condition = doc.getDocumentElement();
+        return new DavException(500, "err", null, condition);
+    }
+
+    @Test
+    public void testGenerateDoesNotInstantiateServerNamedClass() throws Exception {
+        Marker.instantiated = false;
+        final DavException cause = davExceptionNaming(Marker.class.getName());
+        final FileSystemException result = ExceptionConverter.generate(cause);
+        assertNotNull(result);
+        assertFalse(Marker.instantiated, "server-controlled class name must not be instantiated");
+    }
+
+    @Test
+    public void testGenerateStillWrapsExceptionType() throws Exception {
+        final DavException cause = davExceptionNaming(IOException.class.getName());
+        final FileSystemException result = ExceptionConverter.generate(cause);
+        assertNotNull(result);
+        assertInstanceOf(IOException.class, result.getCause());
+    }
+}

--- a/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/ExceptionConverter.java
+++ b/commons-vfs2-jackrabbit2/src/main/java/org/apache/commons/vfs2/provider/webdav4/ExceptionConverter.java
@@ -49,14 +49,17 @@ public final class ExceptionConverter {
                         msg = DomUtil.getChildText(exc, "message", null);
                     }
                     if (DomUtil.hasChildElement(exc, "class", null)) {
-                        final Class<?> cl = Class.forName(DomUtil.getChildText(exc, "class", null));
-                        final Constructor<?> excConstr = cl.getConstructor(String.class);
-                        final Object o = excConstr.newInstance(msg);
-                        if (o instanceof FileSystemException) {
-                            return (FileSystemException) o;
-                        }
-                        if (o instanceof Exception) {
-                            return new FileSystemException(msg, (Exception) o);
+                        final Class<?> cl = Class.forName(DomUtil.getChildText(exc, "class", null), false,
+                                ExceptionConverter.class.getClassLoader());
+                        if (Exception.class.isAssignableFrom(cl)) {
+                            final Constructor<?> excConstr = cl.getConstructor(String.class);
+                            final Object o = excConstr.newInstance(msg);
+                            if (o instanceof FileSystemException) {
+                                return (FileSystemException) o;
+                            }
+                            if (o instanceof Exception) {
+                                return new FileSystemException(msg, (Exception) o);
+                            }
                         }
                     }
                 }

--- a/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/ExceptionConverterTest.java
+++ b/commons-vfs2-jackrabbit2/src/test/java/org/apache/commons/vfs2/provider/webdav4/ExceptionConverterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.provider.webdav4;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.jackrabbit.webdav.DavException;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+/**
+ * Tests {@link ExceptionConverter}.
+ */
+public class ExceptionConverterTest {
+
+    /** Marker class named by the crafted server response; must never be instantiated. */
+    public static final class Marker {
+        static volatile boolean instantiated;
+
+        public Marker(final String message) {
+            instantiated = true;
+        }
+    }
+
+    /**
+     * Builds a {@link DavException} whose error condition carries an {@code <exception><class>} element, as parsed from a
+     * malicious WebDAV server error body.
+     */
+    private DavException davExceptionNaming(final String className) throws Exception {
+        final String xml = "<exception><class>" + className + "</class><message>boom</message></exception>";
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        final Document doc = dbf.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+        final Element condition = doc.getDocumentElement();
+        return new DavException(500, "err", null, condition);
+    }
+
+    @Test
+    public void testGenerateDoesNotInstantiateServerNamedClass() throws Exception {
+        Marker.instantiated = false;
+        final DavException cause = davExceptionNaming(Marker.class.getName());
+        final FileSystemException result = ExceptionConverter.generate(cause);
+        assertNotNull(result);
+        assertFalse(Marker.instantiated, "server-controlled class name must not be instantiated");
+    }
+
+    @Test
+    public void testGenerateStillWrapsExceptionType() throws Exception {
+        final DavException cause = davExceptionNaming(IOException.class.getName());
+        final FileSystemException result = ExceptionConverter.generate(cause);
+        assertNotNull(result);
+        assertInstanceOf(IOException.class, result.getCause());
+    }
+}


### PR DESCRIPTION
`ExceptionConverter.generate` turns a WebDAV server's DAV error response into a `FileSystemException` and hands the response's `<exception><class>` text straight to `Class.forName(...).getConstructor(String.class).newInstance(msg)`, so a malicious or compromised server can make the client load and construct any class on its classpath (CWE-470). Found while auditing the webdav providers for untrusted-input reflection sinks. The fix loads the named class without initializing it and only constructs it when it is an `Exception` subtype, which keeps reconstruction of genuine server exception types working while refusing everything else. The jackrabbit1 (`webdav`) and jackrabbit2 (`webdav4`) providers carry the same sink, so both are fixed; the new `ExceptionConverterTest` cases fail on the current code (the crafted class name is instantiated) and pass with the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
