### PR TITLE
[VFS-863] Content inside brackets in directory/file names is not decoded

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -163,18 +163,26 @@ public final class UriParser {
         boolean ipv6Host = false;
         boolean authorityDetected = false;
         boolean inAuthority = false;
-        int consecutiveSlashes = 0;
+        boolean slashSeenBeforeColon = false;
+        // A network-path reference starts with "//" and its authority immediately follows.
+        if (count >= 2 && buffer.charAt(index) == '/' && buffer.charAt(index + 1) == '/') {
+            authorityDetected = true;
+            inAuthority = true;
+            index += 2;
+            count -= 2;
+        }
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
             if (!authorityDetected) {
                 if (ch == '/') {
-                    consecutiveSlashes++;
-                    if (consecutiveSlashes == 2) {
-                        inAuthority = true;
-                        authorityDetected = true;
-                    }
-                } else {
-                    consecutiveSlashes = 0;
+                    // In this case, the URI has no authority
+                    slashSeenBeforeColon = true;
+                } else if (ch == ':' && !slashSeenBeforeColon && count >= 3
+                        && buffer.charAt(index + 1) == '/' && buffer.charAt(index + 2) == '/') {
+                    authorityDetected = true;
+                    inAuthority = true;
+                    index += 2;
+                    count -= 2;
                 }
             } else if (inAuthority) {
                 if (ch == '[') {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -161,12 +161,29 @@ public final class UriParser {
         int index = offset;
         int count = length;
         boolean ipv6Host = false;
+        boolean authorityDetected = false;
+        boolean inAuthority = false;
+        int consecutiveSlashes = 0;
         for (; count > 0; count--, index++) {
             final char ch = buffer.charAt(index);
-            if (ch == '[') {
-                ipv6Host = true;
-            }
-            if (ch == ']') {
+            if (!authorityDetected) {
+                if (ch == '/') {
+                    consecutiveSlashes++;
+                    if (consecutiveSlashes == 2) {
+                        inAuthority = true;
+                        authorityDetected = true;
+                    }
+                } else {
+                    consecutiveSlashes = 0;
+                }
+            } else if (inAuthority) {
+                if (ch == '[') {
+                    ipv6Host = true;
+                    inAuthority = false;
+                } else if (ch == '/') {
+                    inAuthority = false;
+                }
+            } else if (ipv6Host && ch == ']') {
                 ipv6Host = false;
             }
             if (ch != '%' || ipv6Host) {

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -61,6 +61,22 @@ public class UriParserTest {
     }
 
     @Test
+    public void testDecodePercentInsideBracketsInPath() throws FileSystemException {
+        assertEquals("/outside%text[inside%text]tail",
+                UriParser.decode("/outside%25text[inside%25text]tail"));
+        assertEquals("file:///outside%text[inside%text]tail",
+                UriParser.decode("file:///outside%25text[inside%25text]tail"));
+    }
+
+    @Test
+    public void testDecodePreservesPercentInsideIPv6Host() throws FileSystemException {
+        assertEquals("ftp://[fe80::1%25eth0]/path",
+                UriParser.decode("ftp://[fe80::1%25eth0]/path"));
+        assertEquals("ftp://host/outside%text[inside%text]tail",
+                UriParser.decode("ftp://host/outside%25text[inside%25text]tail"));
+    }
+
+    @Test
     public void testNormalScheme() {
         assertEquals("ftp", UriParser.extractScheme(schemes, "ftp://user:pass@host/some/path/some:file"));
     }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -66,14 +66,28 @@ public class UriParserTest {
                 UriParser.decode("/outside%25text[inside%25text]tail"));
         assertEquals("file:///outside%text[inside%text]tail",
                 UriParser.decode("file:///outside%25text[inside%25text]tail"));
+        assertEquals("ftp://host/outside%text[inside%text]tail",
+                UriParser.decode("ftp://host/outside%25text[inside%25text]tail"));
+    }
+
+    @Test
+    public void testDecodePercentInsideBracketsAfterDoubleSlashInPath() throws FileSystemException {
+        assertEquals("file:/a//[inside%text]",
+                UriParser.decode("file:/a//[inside%25text]"));
+        assertEquals("/a//outside%text[inside%text]tail",
+                UriParser.decode("/a//outside%25text[inside%25text]tail"));
+        assertEquals("ftp://host/redirect=http://other/[inside%text]",
+                UriParser.decode("ftp://host/redirect=http://other/[inside%25text]"));
     }
 
     @Test
     public void testDecodePreservesPercentInsideIPv6Host() throws FileSystemException {
         assertEquals("ftp://[fe80::1%25eth0]/path",
                 UriParser.decode("ftp://[fe80::1%25eth0]/path"));
-        assertEquals("ftp://host/outside%text[inside%text]tail",
-                UriParser.decode("ftp://host/outside%25text[inside%25text]tail"));
+        assertEquals("//[fe80::1%25eth0]/path",
+                UriParser.decode("//[fe80::1%25eth0]/path"));
+        assertEquals("ftp://[fe80::1%25eth0]/[dir%name]",
+                UriParser.decode("ftp://[fe80::1%25eth0]/[dir%25name]"));
     }
 
     @Test

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/UrlTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/UrlTests.java
@@ -19,6 +19,11 @@ package org.apache.commons.vfs2.provider.local;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
 import org.apache.commons.vfs2.AbstractProviderTestCase;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
@@ -63,6 +68,33 @@ public class UrlTests extends AbstractProviderTestCase {
         final FileObject file = getReadFolder().resolveFile("test-hash-#test.txt");
 
         assertEquals(file.toString(), UriParser.decode(file.getURL().toString()));
+    }
+
+    /**
+     * Tests that getURL() round-trips correctly when a directory name contains brackets.
+     */
+    @Test
+    public void testGetUrlRoundTripWithBracketsInPath() throws Exception {
+        final Path tmp = Files.createTempDirectory("vfs-roundtrip");
+        try {
+            final Path child = tmp.resolve("outside%text[inside%text]tail");
+            Files.createDirectories(child);
+
+            final FileSystemManager mgr = VFS.getManager();
+            final FileObject a = mgr.resolveFile(child.toUri().toString());
+            final FileObject b = mgr.resolveFile(a.getURL().toString());
+
+            assertEquals(a.getName().getPath(), b.getName().getPath());
+        } finally {
+            Files.walk(tmp)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.delete(p);
+                        } catch (final IOException ignore) { // NOPMD
+                        }
+                    });
+        }
     }
 
 }

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/UrlTests.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/local/UrlTests.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 import org.apache.commons.vfs2.AbstractProviderTestCase;
 import org.apache.commons.vfs2.FileObject;
@@ -86,14 +87,15 @@ public class UrlTests extends AbstractProviderTestCase {
 
             assertEquals(a.getName().getPath(), b.getName().getPath());
         } finally {
-            Files.walk(tmp)
-                    .sorted(Comparator.reverseOrder())
-                    .forEach(p -> {
-                        try {
-                            Files.delete(p);
-                        } catch (final IOException ignore) { // NOPMD
-                        }
-                    });
+            try (Stream<Path> walk = Files.walk(tmp)) {
+                walk.sorted(Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.delete(p);
+                            } catch (final IOException ignore) { // NOPMD
+                            }
+                        });
+            }
         }
     }
 


### PR DESCRIPTION
In VFS 2.10, content inside brackets in the file URL is not decoded. This is because it is detected to be part of an IPv6 host, although this may not be desired behavior in all circumstances (local file paths that happen to have content in brackets are also affected, despite being unrelated to IPv6).

The fix here is to ensure that we only detect a host inside of the authority as defined by RFC 3986. We do this by detecting the authority as the content between the first instance of `"//"` and the next `"/"`, since the URL takes the format `scheme://<authority>/<path>`. Brackets `outside` of the authority hold no special meaning, so content inside of these brackets will now be decoded.

Bug was most likely introduced by [this PR]( https://github.com/apache/commons-vfs/pull/438/changes#diff-731c9fd149c7d934456163a6eb8c1afebc6be0669986e8ccf5092f164ea0cd30R166)

There appears to be another old, stale PR out for the same issue with a regex approach, but I could not find an associated ticket: https://github.com/apache/commons-vfs/pull/562

AI (Claude Code) was used to write most of the code (I reviewed all output). The fix approach and the design of the test cases were provided by me to the tool.