### PR TITLE
Reject non-ascii hex digits in UriParser percent-decoding

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -18,6 +18,7 @@ package org.apache.commons.vfs2.provider;
 
 import java.util.Arrays;
 
+import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
@@ -59,10 +60,7 @@ public final class UriParser {
      * @return the value 0-15, or {@code -1} if {@code ch} is not an ASCII hexadecimal digit.
      */
     private static int hexDigit(final char ch) {
-        if (ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'F' || ch >= 'a' && ch <= 'f') {
-            return Character.digit(ch, HEX_BASE);
-        }
-        return -1;
+        return CharUtils.isHex(ch) ? Character.digit(ch, HEX_BASE) : -1;
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/UriParser.java
@@ -48,6 +48,24 @@ public final class UriParser {
     private static final char LOW_MASK = 0x0F;
 
     /**
+     * Returns the value of an ASCII hexadecimal digit, or {@code -1} if the character is not one.
+     * <p>
+     * Unlike {@link Character#digit(char, int)}, this only accepts the ASCII digits {@code 0-9}, {@code a-f} and
+     * {@code A-F} that RFC 3986 permits in a percent-encoding, so Unicode look-alikes such as the fullwidth digits are
+     * rejected instead of silently decoded.
+     * </p>
+     *
+     * @param ch the character to convert.
+     * @return the value 0-15, or {@code -1} if {@code ch} is not an ASCII hexadecimal digit.
+     */
+    private static int hexDigit(final char ch) {
+        if (ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'F' || ch >= 'a' && ch <= 'f') {
+            return Character.digit(ch, HEX_BASE);
+        }
+        return -1;
+    }
+
+    /**
      * Encodes and appends a string to a StringBuilder.
      *
      * @param buffer The StringBuilder to append to.
@@ -88,8 +106,8 @@ public final class UriParser {
                 }
 
                 // Decode
-                final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
-                final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
+                final int dig1 = hexDigit(buffer.charAt(index + 1));
+                final int dig2 = hexDigit(buffer.charAt(index + 2));
                 if (dig1 == -1 || dig2 == -1) {
                     throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
                             buffer.substring(index, index + 3));
@@ -204,8 +222,8 @@ public final class UriParser {
             }
 
             // Decode
-            final int dig1 = Character.digit(buffer.charAt(index + 1), HEX_BASE);
-            final int dig2 = Character.digit(buffer.charAt(index + 2), HEX_BASE);
+            final int dig1 = hexDigit(buffer.charAt(index + 1));
+            final int dig2 = hexDigit(buffer.charAt(index + 2));
             if (dig1 == -1 || dig2 == -1) {
                 throw new FileSystemException("vfs.provider/invalid-escape-sequence.error",
                         buffer.substring(index, index + 3));

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/UriParserTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.vfs2.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.vfs2.FileSystemException;
@@ -73,6 +74,22 @@ public class UriParserTest {
                 UriParser.decode("file:///outside%25text[inside%25text]tail"));
         assertEquals("ftp://host/outside%text[inside%text]tail",
                 UriParser.decode("ftp://host/outside%25text[inside%25text]tail"));
+    }
+
+    @Test
+    public void testDecodeAcceptsAsciiHexDigits() throws FileSystemException {
+        // Valid ASCII escapes still decode, both letter cases.
+        assertEquals("../", UriParser.decode("%2e%2E%2f"));
+        assertEquals("Az", UriParser.decode("%41%7a"));
+    }
+
+    @Test
+    public void testDecodeRejectsNonAsciiHexDigits() {
+        // RFC 3986 pct-encoding is ASCII HEXDIG only. Fullwidth "2e2e2f" would otherwise decode to "../".
+        assertThrows(FileSystemException.class, () -> UriParser.decode("%２ｅ%２ｅ%２ｆ"));
+        // A single non-ASCII digit in either nibble is enough to reject: arabic-indic five (U+0665).
+        assertThrows(FileSystemException.class, () -> UriParser.decode("%4٥"));
+        assertThrows(FileSystemException.class, () -> UriParser.decode("%٥5"));
     }
 
     @Test


### PR DESCRIPTION
`UriParser.decode` and `canonicalizePath` parse the two digits of a `%XX` escape with `Character.digit(ch, 16)`, which accepts non-ascii look-alikes such as the fullwidth digits and arabic-indic digits, not just the ascii `HEXDIG` that RFC 3986 permits, so the fullwidth form of `%2e%2e%2f` decodes to `../` and slips past any ascii filter run on the raw string. Found while auditing the percent-decode path after the recent VFS-863 bracket change. The fix routes both nibbles through a small ascii-only `hexDigit` helper so a non-ascii digit raises the existing `invalid-escape-sequence` error and valid `%XX` decoding is unchanged; the new `UriParserTest` cases fail on the current code and pass with the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
