### PR TITLE
Replace the shared vfs_cache temp dir in DefaultFileReplicator

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileReplicator.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileReplicator.java
@@ -17,10 +17,11 @@
 package org.apache.commons.vfs2.impl;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Random;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
@@ -91,7 +92,7 @@ public class DefaultFileReplicator extends AbstractVfsComponent implements FileR
             fileCount++;
         }
 
-        return createAndAddFile(tempDir, actualBaseName);
+        return createAndAddFile(getTempDir(), actualBaseName);
     }
 
     /**
@@ -125,7 +126,7 @@ public class DefaultFileReplicator extends AbstractVfsComponent implements FileR
      * @throws FileSystemException if a file system error occurs.
      */
     protected File createAndAddFile(final File parent, final String baseName) throws FileSystemException {
-        final File file = createFile(tempDir, baseName);
+        final File file = createFile(getTempDir(), baseName);
         // Keep track to delete later
         addFile(file);
         return file;
@@ -184,17 +185,24 @@ public class DefaultFileReplicator extends AbstractVfsComponent implements FileR
     }
 
     /**
-     * Initializes this component.
+     * Gets the directory that holds the replicated files, creating it on first use.
+     * <p>
+     * Unless a directory was supplied to {@link #DefaultFileReplicator(File)}, the directory is created with
+     * {@link Files#createTempDirectory(String, java.nio.file.attribute.FileAttribute...)}, which picks an
+     * unpredictable name and, on POSIX file systems, restricts it to the owner.
+     * </p>
      *
-     * @throws FileSystemException if an error occurs.
+     * @return the directory that holds the replicated files.
+     * @throws FileSystemException if the directory cannot be created.
      */
-    @Override
-    public void init() throws FileSystemException {
+    private synchronized File getTempDir() throws FileSystemException {
         if (tempDir == null) {
-            tempDir = new File(FileUtils.getTempDirectoryPath(), "vfs_cache").getAbsoluteFile();
+            try {
+                tempDir = Files.createTempDirectory("vfs_cache").toFile().getAbsoluteFile();
+            } catch (final IOException e) {
+                throw new FileSystemException("vfs.impl/init-replicator.error", e);
+            }
         }
-
-        fileCount = RANDOM.nextInt() & MASK;
 
         if (!tempDirMessageLogged) {
             final String message = Messages.getString("vfs.impl/temp-dir.debug", tempDir);
@@ -202,6 +210,18 @@ public class DefaultFileReplicator extends AbstractVfsComponent implements FileR
 
             tempDirMessageLogged = true;
         }
+
+        return tempDir;
+    }
+
+    /**
+     * Initializes this component.
+     *
+     * @throws FileSystemException if an error occurs.
+     */
+    @Override
+    public void init() throws FileSystemException {
+        fileCount = RANDOM.nextInt() & MASK;
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileReplicator.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileReplicator.java
@@ -120,13 +120,13 @@ public class DefaultFileReplicator extends AbstractVfsComponent implements FileR
     /**
      * Adds a file.
      *
-     * @param parent ignored.
+     * @param parent The parent directory of the new file.
      * @param baseName The base file name.
      * @return A File.
      * @throws FileSystemException if a file system error occurs.
      */
     protected File createAndAddFile(final File parent, final String baseName) throws FileSystemException {
-        final File file = createFile(getTempDir(), baseName);
+        final File file = createFile(parent, baseName);
         // Keep track to delete later
         addFile(file);
         return file;

--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileReplicatorTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/impl/DefaultFileReplicatorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.vfs2.FileSystemException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link DefaultFileReplicator}.
+ */
+public class DefaultFileReplicatorTest {
+
+    private File allocateTempDir() throws FileSystemException {
+        final DefaultFileReplicator replicator = new DefaultFileReplicator();
+        replicator.init();
+        return replicator.allocateFile("test.txt").getParentFile();
+    }
+
+    @Test
+    public void testTempDirIsNotSharedByName() throws Exception {
+        final File tempDir = allocateTempDir();
+        try {
+            assertNotEquals(new File(FileUtils.getTempDirectoryPath(), "vfs_cache").getAbsoluteFile(), tempDir,
+                    "the replica directory must not use a name another user can guess and pre-create");
+            assertTrue(tempDir.isDirectory(), tempDir + " was not created");
+        } finally {
+            FileUtils.deleteQuietly(tempDir);
+        }
+    }
+
+    @Test
+    public void testTempDirIsOwnerOnly() throws Exception {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        final File tempDir = allocateTempDir();
+        try {
+            assertEquals(PosixFilePermissions.fromString("rwx------"),
+                    Files.getPosixFilePermissions(tempDir.toPath()));
+        } finally {
+            FileUtils.deleteQuietly(tempDir);
+        }
+    }
+}


### PR DESCRIPTION
`DefaultFileReplicator` pins its replica directory to `<java.io.tmpdir>/vfs_cache`, a fixed name under a directory every local user can write to, and leaves creation to `mkdirs` under the default umask. Everything the library replicates lands there world-readable, including the whole remote archive that `ZipFileSystem` and `TarFileSystem` copy through `replicateFile` before opening it. Because the name is known up front, another local user can also pre-create `vfs_cache` as a symlink and collect the replicas, or swap a replicated jar before `VFSClassLoader` reads it; found while auditing where the library writes files on the caller's behalf.

Allocate the directory with `Files.createTempDirectory` on first use instead. It picks an unguessable name and creates it `rwx------` on POSIX file systems in a single step, so there is no window between creation and a chmod. Keeping this in the replicator puts the guarantee where the directory's lifetime is already managed, and an application that wants a specific location still passes one to the `DefaultFileReplicator(File)` constructor.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
