### PR TITLE
Fix FtpProviderUserDirTest on Java 8 on Ubuntu.

### DIFF
--- a/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderUserDirTest.java
+++ b/commons-vfs2/src/test/java/org/apache/commons/vfs2/provider/ftp/FtpProviderUserDirTest.java
@@ -94,8 +94,9 @@ public class FtpProviderUserDirTest extends ProviderTestSuiteJunit5 {
         }
 
         // Create test directory structure with homeDirIsRoot
-        final File testDir = new File(getTestDirectory());
-        final File rootDir = new File(testDir, "homeDirIsRoot");
+        // Use src/test/resources/test-data as source to avoid copying files modified by permission tests
+        final File testDir = new File("src/test/resources/test-data");
+        final File rootDir = new File(getTestDirectory(), "homeDirIsRoot");
         final File homesDir = new File(rootDir, "home");
         final File initialDir = new File(homesDir, "test");
         FileUtils.deleteDirectory(rootDir);


### PR DESCRIPTION
Instead of copying from the mutable target/test-classes/test-data which can contain the permission.txt left unreadable by PermissionsTests. The homeDirIsRoot tree is still created under getTestDirectory() so the embedded FTP server sees the correct location,
but the data it is seeded with is clean and the Java 8 Ubuntu AccessDeniedException:
target/test-classes/test-data/write-tests/permission.txt no longer occurs.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to research the issue.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice. Here, I rewrote the test setup.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
